### PR TITLE
Add records dashboard performance indexes

### DIFF
--- a/database/migrations/2026_05_21_142100_add_dashboard_perf_indexes_to_records_table.php
+++ b/database/migrations/2026_05_21_142100_add_dashboard_perf_indexes_to_records_table.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Adds two indexes that materially speed up the project dashboard once a
+     * single project accumulates a few hundred thousand records.
+     *
+     * Observed on a 2,000-bot internal load test (~700k records in 24h on
+     * MariaDB 11): the dashboard time-bucket query (no type filter) and the
+     * "top exceptions by fingerprint" query both regressed past the 30s
+     * Octane request timeout. The existing composite
+     * `(project_id, type, created_at)` only helps when `type` is included
+     * in the WHERE clause; aggregations that group by `type` or filter by
+     * `fingerprint` were falling back to broader scans.
+     *
+     * Index choices:
+     * - `(project_id, created_at)` — covers `WHERE project_id=? AND
+     *   created_at >= ?` with no `type` predicate (used by the per-project
+     *   time-series widgets and the records timeline).
+     * - `(project_id, type, fingerprint)` — covers `WHERE project_id=? AND
+     *   type='exception' GROUP BY fingerprint` and the equivalent path for
+     *   `slow-query`/`request` fingerprint aggregation.
+     *
+     * Both indexes are additive — the existing `(project_id, type,
+     * created_at)` index is left in place because it remains the right
+     * choice for filtered time queries.
+     */
+    public function up(): void
+    {
+        Schema::table('records', function (Blueprint $table) {
+            $table->index(['project_id', 'created_at'], 'records_project_created_idx');
+            $table->index(['project_id', 'type', 'fingerprint'], 'records_project_type_fingerprint_idx');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('records', function (Blueprint $table) {
+            $table->dropIndex('records_project_type_fingerprint_idx');
+            $table->dropIndex('records_project_created_idx');
+        });
+    }
+};


### PR DESCRIPTION
## Why

The existing `(project_id, type, created_at)` composite on `records` covers filtered time queries (`WHERE project_id=? AND type=? AND created_at >= ?`) but the project dashboard also runs:

1. **Time-series aggregations across all record types** — `WHERE project_id=? AND created_at >= ? GROUP BY ...`. Without `type` in the WHERE clause the optimizer cannot use the existing composite and falls back to `records_created_at_index` plus a filesort.
2. **Top exceptions / slow queries by fingerprint** — `WHERE project_id=? AND type='exception' GROUP BY fingerprint`. The existing composite helps the WHERE part, but the GROUP BY then needs a separate pass.

## What

Adds two additive indexes:

| Index | Columns | Helps |
|---|---|---|
| `records_project_created_idx` | `(project_id, created_at)` | dashboard time-series widgets, project records timeline |
| `records_project_type_fingerprint_idx` | `(project_id, type, fingerprint)` | top exceptions / slow-queries grouped by fingerprint |

Both are additive — `(project_id, type, created_at)` stays in place because it remains the right choice for filtered time queries.

## Reproduction

Observed on a self-hosted LaraOwl with ~700k records in a single 24h window (internal load test ingesting from a 2,000-bot run). The dashboard hit the default Octane `max_execution_time=30s` per-request limit and returned HTTP 500.

After adding these indexes + `ANALYZE TABLE records`, the heaviest dashboard queries run under one second on MariaDB 11 and the dashboard loads cleanly with the default Octane configuration.

## Test plan

- [x] `php artisan migrate` applies cleanly on MariaDB 11 / MySQL 8
- [x] `php artisan migrate:rollback` removes both indexes cleanly
- [x] Real-world dashboard load with ~700k records in a single project completes inside the default Octane timeout
- [ ] No noticeable write-path regression observed on the ingest side (additive indexes are cheap on append-only tables, but maintainers may want to confirm on their own ingest profile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)