### PR TITLE
feat: add sortable columns to the requests table

### DIFF
--- a/app/Http/Controllers/Projects/RecordController.php
+++ b/app/Http/Controllers/Projects/RecordController.php
@@ -64,7 +64,10 @@ class RecordController extends Controller
 
     protected function renderRequestsIndex(Project $project, string $period, ?string $from, ?string $to): Response
     {
-        return $this->renderWithStats('projects/requests', $this->recordService->getRequestStats($project, $period, $from, $to), $project, $period, $from, $to);
+        $sort = request()->query('sort', 'total');
+        $direction = request()->query('direction', 'desc');
+
+        return $this->renderWithStats('projects/requests', $this->recordService->getRequestStats($project, $period, $from, $to, $sort, $direction), $project, $period, $from, $to);
     }
 
     protected function renderUsersIndex(Project $project, string $period, ?string $from, ?string $to): Response

--- a/app/Services/RecordService.php
+++ b/app/Services/RecordService.php
@@ -38,8 +38,12 @@ class RecordService
     /**
      * Aggregate Request Data
      */
-    public function getRequestStats(Project $project, ?string $period = null, ?string $from = null, ?string $to = null): array
+    public function getRequestStats(Project $project, ?string $period = null, ?string $from = null, ?string $to = null, string $sort = 'total', string $direction = 'desc'): array
     {
+        $allowedSorts = ['method', 'path', 'total', 'ok_count', 'client_error_count', 'server_error_count', 'avg_duration', 'p95_duration'];
+        $sort = in_array($sort, $allowedSorts) ? $sort : 'total';
+        $direction = $direction === 'asc' ? 'asc' : 'desc';
+
         $overview = $project->records()
             ->ofType('request')
             ->forPeriod($period, $from, $to)
@@ -59,7 +63,7 @@ class RecordService
                 ->forPeriod($period, $from, $to)
                 ->select([
                     DB::raw("JSON_UNQUOTE(COALESCE(JSON_EXTRACT(payload, '$.method'), 'GET')) as method"),
-                    DB::raw("JSON_UNQUOTE(COALESCE(JSON_EXTRACT(payload, '$.path'), '/')) as path"),
+                    DB::raw("JSON_UNQUOTE(COALESCE(JSON_EXTRACT(payload, '$.route_path'), '/')) as path"),
                     'fingerprint as hash',
                     DB::raw('COUNT(*) as total'),
                     DB::raw("SUM(CASE WHEN JSON_UNQUOTE(JSON_EXTRACT(payload, '$.status_code')) BETWEEN 100 AND 399 THEN 1 ELSE 0 END) as ok_count"),
@@ -69,7 +73,7 @@ class RecordService
                     DB::raw("MAX(JSON_EXTRACT(payload, '$.duration')) as p95_duration"),
                 ])
                 ->groupBy('method', 'path', 'fingerprint')
-                ->orderBy('total', 'desc')
+                ->orderBy($sort, $direction)
                 ->paginate(20)->withQueryString(),
             'timeSeries' => $this->getDetailedTimeSeries($project, 'request', $period, $from, $to),
             'overview' => [
@@ -80,6 +84,8 @@ class RecordService
                 'max_duration' => round($overview->max_duration ?? 0, 2),
                 'min_duration' => round($overview->min_duration ?? 0, 2),
             ],
+            'sort' => $sort,
+            'direction' => $direction,
         ];
     }
 

--- a/app/Services/RecordService.php
+++ b/app/Services/RecordService.php
@@ -63,7 +63,7 @@ class RecordService
                 ->forPeriod($period, $from, $to)
                 ->select([
                     DB::raw("JSON_UNQUOTE(COALESCE(JSON_EXTRACT(payload, '$.method'), 'GET')) as method"),
-                    DB::raw("JSON_UNQUOTE(COALESCE(JSON_EXTRACT(payload, '$.route_path'), '/')) as path"),
+                    DB::raw("JSON_UNQUOTE(COALESCE(JSON_EXTRACT(payload, '$.path'), '/')) as path"),
                     'fingerprint as hash',
                     DB::raw('COUNT(*) as total'),
                     DB::raw("SUM(CASE WHEN JSON_UNQUOTE(JSON_EXTRACT(payload, '$.status_code')) BETWEEN 100 AND 399 THEN 1 ELSE 0 END) as ok_count"),

--- a/resources/js/pages/projects/requests/index.tsx
+++ b/resources/js/pages/projects/requests/index.tsx
@@ -1,5 +1,5 @@
 import { Head, Link, usePage, router } from '@inertiajs/react';
-import { Activity, AlertCircle, ArrowUpRight, Globe } from 'lucide-react';
+import { Activity, AlertCircle, ArrowUpRight, ChevronDown, ChevronUp, ChevronsUpDown, Globe } from 'lucide-react';
 import { useEffect } from 'react';
 import {
     BarChart,
@@ -29,11 +29,15 @@ export default function RequestsIndex({
     timeSeries,
     stats,
     overview,
+    sort: currentSort = 'total',
+    direction: currentDirection = 'desc',
 }: {
     requests: any;
     timeSeries: any;
     stats: any;
     overview: any;
+    sort?: string;
+    direction?: string;
 }) {
     const { props }: any = usePage();
     const teamSlug = props.current_team?.slug || props.currentTeam?.slug;
@@ -58,6 +62,25 @@ export default function RequestsIndex({
     }, []);
 
     const data = requests.data || [];
+
+    const handleSort = (column: string) => {
+        const newDirection =
+            currentSort === column && currentDirection === 'desc' ? 'asc' : 'desc';
+        router.get(
+            window.location.pathname,
+            { ...Object.fromEntries(new URLSearchParams(window.location.search)), sort: column, direction: newDirection },
+            { preserveScroll: true, preserveState: true },
+        );
+    };
+
+    const SortIcon = ({ column }: { column: string }) => {
+        if (currentSort !== column) {
+            return <ChevronsUpDown className="ml-1 inline h-3 w-3 opacity-40" />;
+        }
+        return currentDirection === 'asc'
+            ? <ChevronUp className="ml-1 inline h-3 w-3" />
+            : <ChevronDown className="ml-1 inline h-3 w-3" />;
+    };
 
     const getMethodColor = (method: string) => {
         switch (method?.toUpperCase()) {
@@ -341,29 +364,53 @@ export default function RequestsIndex({
                                 <Table>
                                     <TableHeader className="bg-muted/30">
                                         <TableRow className="border-border hover:bg-transparent">
-                                            <TableHead className="text-[10px] font-bold text-muted-foreground uppercase">
-                                                Method
+                                            <TableHead
+                                                className="cursor-pointer select-none text-[10px] font-bold text-muted-foreground uppercase hover:text-foreground"
+                                                onClick={() => handleSort('method')}
+                                            >
+                                                Method<SortIcon column="method" />
                                             </TableHead>
-                                            <TableHead className="text-[10px] font-bold text-muted-foreground uppercase">
-                                                Path
+                                            <TableHead
+                                                className="cursor-pointer select-none text-[10px] font-bold text-muted-foreground uppercase hover:text-foreground"
+                                                onClick={() => handleSort('path')}
+                                            >
+                                                Path<SortIcon column="path" />
                                             </TableHead>
-                                            <TableHead className="text-center text-[10px] font-bold text-muted-foreground uppercase">
-                                                1/2/3xx
+                                            <TableHead
+                                                className="cursor-pointer select-none text-center text-[10px] font-bold text-muted-foreground uppercase hover:text-foreground"
+                                                onClick={() => handleSort('ok_count')}
+                                            >
+                                                1/2/3xx<SortIcon column="ok_count" />
                                             </TableHead>
-                                            <TableHead className="text-center text-[10px] font-bold text-muted-foreground uppercase">
-                                                4xx
+                                            <TableHead
+                                                className="cursor-pointer select-none text-center text-[10px] font-bold text-muted-foreground uppercase hover:text-foreground"
+                                                onClick={() => handleSort('client_error_count')}
+                                            >
+                                                4xx<SortIcon column="client_error_count" />
                                             </TableHead>
-                                            <TableHead className="text-center text-[10px] font-bold text-muted-foreground uppercase">
-                                                5xx
+                                            <TableHead
+                                                className="cursor-pointer select-none text-center text-[10px] font-bold text-muted-foreground uppercase hover:text-foreground"
+                                                onClick={() => handleSort('server_error_count')}
+                                            >
+                                                5xx<SortIcon column="server_error_count" />
                                             </TableHead>
-                                            <TableHead className="text-right text-[10px] font-bold text-muted-foreground uppercase">
-                                                Total
+                                            <TableHead
+                                                className="cursor-pointer select-none text-right text-[10px] font-bold text-muted-foreground uppercase hover:text-foreground"
+                                                onClick={() => handleSort('total')}
+                                            >
+                                                Total<SortIcon column="total" />
                                             </TableHead>
-                                            <TableHead className="text-right text-[10px] font-bold text-muted-foreground uppercase">
-                                                Avg
+                                            <TableHead
+                                                className="cursor-pointer select-none text-right text-[10px] font-bold text-muted-foreground uppercase hover:text-foreground"
+                                                onClick={() => handleSort('avg_duration')}
+                                            >
+                                                Avg<SortIcon column="avg_duration" />
                                             </TableHead>
-                                            <TableHead className="text-right text-[10px] font-bold text-muted-foreground uppercase">
-                                                P95
+                                            <TableHead
+                                                className="cursor-pointer select-none text-right text-[10px] font-bold text-muted-foreground uppercase hover:text-foreground"
+                                                onClick={() => handleSort('p95_duration')}
+                                            >
+                                                P95<SortIcon column="p95_duration" />
                                             </TableHead>
                                             <TableHead className="w-[50px]"></TableHead>
                                         </TableRow>


### PR DESCRIPTION
The requests monitoring table previously had a fixed sort order (total requests descending). This PR adds full column sorting support so you can quickly find the slowest, most error-prone, or highest-traffic routes.

Changes:

  - RecordService::getRequestStats — accepts $sort and $direction parameters. The sort column is validated against an allowlist (method, path, total,
  ok_count, client_error_count, server_error_count, avg_duration, p95_duration) to prevent SQL injection. Returns the active sort state back to the
  frontend.
  - RecordController::renderRequestsIndex — reads sort and direction from the query string and passes them to the service.
  - Requests index page — all 8 table headers are now clickable. Clicking an active column toggles between descending and ascending; clicking a new
  column defaults to descending. Sort state is reflected with ChevronUp/ChevronDown icons on the active column and a subtle ChevronsUpDown indicator on
  inactive ones. Sort params are preserved in the URL alongside existing filters (period, pagination, etc.).

Example filtered by `avg`:

<img width="1231" height="352" alt="Screenshot 2026-06-17 at 17 03 08" src="https://github.com/user-attachments/assets/a99ec122-3dad-4b82-8a0c-de028ef5849e" />

Note: my request payload included `route_path` instead of `path`, therefore I changed that in the select of the RecordServce. If that isn't meant to be changed, please let me know how my payload would include a `path` key so the table shows the correct routes.
