### PR TITLE
chore: update README with storage:link command

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ php artisan key:generate
 # Configure your database in .env, then:
 php artisan migrate
 
+# Link the storage directory (required for uploaded project avatars to display)
+php artisan storage:link
+
 # Build frontend assets
 npm run build
 


### PR DESCRIPTION
Add instructions to link storage directory for working avatars. (it was broken img tag after upload image, which was physically saved in storage, but not visible in browser after that)