### PR TITLE
fix: prevent issue detail page crash on string stack traces

### DIFF
--- a/resources/js/pages/projects/issues/show.tsx
+++ b/resources/js/pages/projects/issues/show.tsx
@@ -88,7 +88,7 @@ export default function IssueShow({
         }
     };
 
-    const stackTrace = payload.trace || [];
+    const stackTrace = Array.isArray(payload.trace) ? payload.trace : [];
 
     return (
         <div className="mx-auto max-w-[1600px] animate-in space-y-6 duration-700 fade-in slide-in-from-bottom-4">


### PR DESCRIPTION
Fix blank/black screen on the issue detail page when an exception payload's `trace` arrives as a string (e.g. raw `getTraceAsString()` output) instead of an array of frames. The code did `payload.trace || []`, so a non-empty string passed through, and `stackTrace.slice(0, 15).map()` threw `slice(...).map is not a function`, crashing the whole React render. Now `trace` is only treated as frames when it's actually an array, otherwise the page falls back to the existing "Raw Payload" view.