### PR TITLE
feat: add Gotify message integration type

### DIFF
--- a/app/Http/Controllers/Projects/IntegrationController.php
+++ b/app/Http/Controllers/Projects/IntegrationController.php
@@ -27,7 +27,7 @@ class IntegrationController extends Controller
     {
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            'type' => ['required', 'string', 'in:slack,discord,telegram,webhook,email'],
+            'type' => ['required', 'string', 'in:slack,discord,telegram,webhook,email,gotify'],
             'data' => ['required', 'array'],
         ]);
 

--- a/app/Services/IntegrationService.php
+++ b/app/Services/IntegrationService.php
@@ -61,6 +61,7 @@ class IntegrationService
             'telegram' => $this->sendToTelegram($integration, $title, $message, $fields, $url),
             'webhook' => $this->sendToWebhook($integration, $title, $message, $fields, $url),
             'email' => $this->sendToEmail($integration, $title, $message, $fields, $url),
+            'gotify' => $this->sendToGotify($integration, $title, $message, $fields, $url),
             default => null,
         };
     }
@@ -202,6 +203,34 @@ class IntegrationService
         });
     }
 
+    protected function sendToGotify(Integration $integration, string $title, string $message, array $fields = [], ?string $url = null): void
+    {
+        $serverUrl = $integration->data['server_url'] ?? null;
+        $appToken = $integration->data['app_token'] ?? null;
+        if (! $serverUrl || ! $appToken) {
+            return;
+        }
+
+        $body = '';
+        foreach ($fields as $label => $value) {
+            $body .= "**{$label}:** {$value}\n";
+        }
+        $body .= "\n{$message}\n";
+        if ($url) {
+            $body .= "\n[View Details]({$url})";
+        }
+
+        Http::withHeaders(['X-Gotify-Key' => $appToken])
+            ->post(rtrim($serverUrl, '/').'/message', [
+                'title' => $title,
+                'message' => $body,
+                'priority' => 5,
+                'extras' => [
+                    'client::display' => ['contentType' => 'text/markdown'],
+                ],
+            ]);
+    }
+
     public function getAvailableTypes(): array
     {
         return [
@@ -239,6 +268,14 @@ class IntegrationService
                 'name' => 'Email',
                 'fields' => [
                     ['name' => 'email', 'label' => 'Email Address', 'type' => 'email', 'placeholder' => 'ops@example.com'],
+                ],
+            ],
+            [
+                'id' => 'gotify',
+                'name' => 'Gotify',
+                'fields' => [
+                    ['name' => 'server_url', 'label' => 'Server URL', 'type' => 'url', 'placeholder' => 'https://gotify.example.com'],
+                    ['name' => 'app_token', 'label' => 'App Token', 'type' => 'password', 'placeholder' => 'A...'],
                 ],
             ],
         ];

--- a/app/Services/IntegrationService.php
+++ b/app/Services/IntegrationService.php
@@ -213,7 +213,10 @@ class IntegrationService
 
         $body = '';
         foreach ($fields as $label => $value) {
-            $body .= "**{$label}:** {$value}\n";
+            if ($value === null || $value === '') {
+                continue;
+            }
+            $body .= "- **{$label}:** {$value}\n";
         }
         $body .= "\n{$message}\n";
         if ($url) {

--- a/resources/js/pages/projects/settings/index.tsx
+++ b/resources/js/pages/projects/settings/index.tsx
@@ -67,6 +67,7 @@ const iconMap: any = {
     webhook: Globe,
     telegram: Send,
     email: Mail,
+    gotify: MessageSquare,
 };
 
 export default function ProjectSettings({
@@ -1157,6 +1158,13 @@ export default function ProjectSettings({
                                                 desc: 'Send an email to any address.',
                                                 color: 'from-purple-500/20 to-indigo-500/20',
                                                 icon: Mail,
+                                            },
+                                            {
+                                                id: 'gotify',
+                                                name: 'Gotify',
+                                                desc: 'Push alerts to your self-hosted Gotify server.',
+                                                color: 'from-lime-500/20 to-green-500/20',
+                                                icon: Bell,
                                             },
                                         ].map((item) => {
                                             const isConfigured =

--- a/tests/Feature/GotifyIntegrationTest.php
+++ b/tests/Feature/GotifyIntegrationTest.php
@@ -34,7 +34,7 @@ class GotifyIntegrationTest extends TestCase
             $integration,
             '🚨 New Alert',
             'Something broke.',
-            ['Project' => 'Demo'],
+            ['Project' => 'Demo', 'Priority' => ''],
             'https://laraowl.test/issues/1',
         );
 
@@ -44,6 +44,7 @@ class GotifyIntegrationTest extends TestCase
                 && $request['title'] === '🚨 New Alert'
                 && str_contains($request['message'], 'Something broke.')
                 && str_contains($request['message'], '**Project:** Demo')
+                && ! str_contains($request['message'], 'Priority')
                 && $request['priority'] === 5;
         });
 

--- a/tests/Feature/GotifyIntegrationTest.php
+++ b/tests/Feature/GotifyIntegrationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Project;
+use App\Models\Team;
+use App\Services\IntegrationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class GotifyIntegrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_sends_a_notification_to_gotify()
+    {
+        Http::fake();
+
+        $team = Team::factory()->create();
+        $project = Project::factory()->create(['team_id' => $team->id]);
+
+        $integration = $project->integrations()->create([
+            'name' => 'My Gotify',
+            'type' => 'gotify',
+            'data' => [
+                'server_url' => 'https://gotify.example.com/',
+                'app_token' => 'secret-token',
+            ],
+            'is_enabled' => true,
+        ]);
+
+        app(IntegrationService::class)->send(
+            $integration,
+            '🚨 New Alert',
+            'Something broke.',
+            ['Project' => 'Demo'],
+            'https://laraowl.test/issues/1',
+        );
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://gotify.example.com/message'
+                && $request->hasHeader('X-Gotify-Key', 'secret-token')
+                && $request['title'] === '🚨 New Alert'
+                && str_contains($request['message'], 'Something broke.')
+                && str_contains($request['message'], '**Project:** Demo')
+                && $request['priority'] === 5;
+        });
+
+        $this->assertEquals('healthy', $integration->fresh()->status);
+    }
+
+    public function test_it_does_not_send_when_gotify_config_is_missing()
+    {
+        Http::fake();
+
+        $team = Team::factory()->create();
+        $project = Project::factory()->create(['team_id' => $team->id]);
+
+        $integration = $project->integrations()->create([
+            'name' => 'Broken Gotify',
+            'type' => 'gotify',
+            'data' => ['server_url' => 'https://gotify.example.com'],
+            'is_enabled' => true,
+        ]);
+
+        app(IntegrationService::class)->send($integration, 'Test', 'Message');
+
+        Http::assertNothingSent();
+    }
+}


### PR DESCRIPTION
Adds a Gotify push-notification integration: a sendToGotify driver posting to {server_url}/message with the X-Gotify-Key header, the type in available types and store validation, the marketplace UI entry, and a feature test covering send and missing-config cases.