### PR TITLE
fix: workspace switcher routes to wrong team when selecting a project

### DIFF
--- a/resources/js/components/workspace-switcher.tsx
+++ b/resources/js/components/workspace-switcher.tsx
@@ -42,17 +42,18 @@ export function WorkspaceSwitcher({
     }, [props.teams, search]);
 
     const switchProject = (project: any) => {
-        if (!currentProject) {
-            router.visit(`/${currentTeam.slug}/${project.slug}/dashboard`);
-
-            return;
-        }
+        const projectTeam =
+            (props.teams ?? []).find((t: any) => t.id === project.team_id) ??
+            currentTeam;
+        const newPrefix = `/${projectTeam.slug}/${project.slug}`;
 
         const currentUrl = window.location.pathname;
-        const oldPrefix = `/${currentTeam.slug}/${currentProject.slug}`;
-        const newPrefix = `/${currentTeam.slug}/${project.slug}`;
+        const oldPrefix =
+            currentTeam && currentProject
+                ? `/${currentTeam.slug}/${currentProject.slug}`
+                : null;
 
-        if (currentUrl.includes(oldPrefix)) {
+        if (oldPrefix && currentUrl.includes(oldPrefix)) {
             router.visit(currentUrl.replace(oldPrefix, newPrefix));
         } else {
             router.visit(newPrefix + '/dashboard');


### PR DESCRIPTION
## Problem

Selecting a project from a different team in the sidebar workspace switcher navigates to the **currently-viewed team's** slug instead of the selected project's team. Because the `{project}` route binding resolves globally, the page still loads, but the dashboard badge shows a mismatched team (e.g. picking a Team A project while on Team B shows *Team B · Project A*).

## Cause

`switchProject` in `resources/js/components/workspace-switcher.tsx` built the destination URL from `currentTeam.slug` rather than the team the chosen project belongs to.

## Fix

Resolve the project's own team via its `team_id` (already present in the `projects`/`teams` props, and already used for grouping in the same dropdown) and build the URL from that team's slug.

## Testing

Verified manually in the running app: from one team, selecting a project belonging to another team now navigates to `/{project-team}/{project}/dashboard` and the badge shows the correct team + project. No automated test added — the project currently has no JS/browser test setup (no vitest/jest, no `tests/Browser`), and this is a client-side URL fix.