### PR TITLE
feat: MCP server for projects, issues and telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="#features">Features</a> •
   <a href="#quick-start">Quick Start</a> •
   <a href="#client-integration">Client Integration</a> •
+  <a href="#connect-an-ai-agent-mcp">AI Agents</a> •
   <a href="#architecture">Architecture</a> •
   <a href="#production-deployment">Production</a> •
   <a href="#license">License</a>
@@ -134,6 +135,13 @@ Set custom performance budgets per project:
 - All incoming data is processed via **Laravel Queues**
 - Zero-latency API responses — data is queued immediately
 - Broadcasting happens in the background worker
+
+### AI Agent Access (MCP)
+
+- **Model Context Protocol server** so AI coding agents can work with your data
+- Read projects, list and inspect issues, and query telemetry
+- Update issue status and comment on issues from the agent
+- Scoped to the user's teams with **Sanctum tokens**; record output is sanitized
 
 ---
 
@@ -286,6 +294,27 @@ LOG_STACK=stack,laraowl
 ```
 
 That's it. Your application will immediately begin sending telemetry data to the LaraOwl server.
+
+---
+
+## Connect an AI Agent (MCP)
+
+LaraOwl exposes a [Model Context Protocol](https://modelcontextprotocol.io) server so AI coding agents can read projects, triage issues and query telemetry on your behalf. Every tool is scoped to your teams.
+
+Generate a token from **Settings → MCP Tokens**, or via Artisan:
+
+```bash
+php artisan laraowl:mcp-token user@example.com --name=mcp
+```
+
+Then point your agent at the server. For Claude Code:
+
+```bash
+claude mcp add --transport http laraowl https://your-laraowl-server.com/mcp \
+  --header "Authorization: Bearer <token>"
+```
+
+Available tools: `list-projects`, `list-issues`, `get-issue`, `query-telemetry`, `update-issue-status`, `comment-on-issue`.
 
 ---
 

--- a/app/Console/Commands/IssueMcpToken.php
+++ b/app/Console/Commands/IssueMcpToken.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+
+class IssueMcpToken extends Command
+{
+    protected $signature = 'laraowl:mcp-token {user : User id or email} {--name=mcp : Token name}';
+
+    protected $description = 'Issue a Sanctum personal access token for MCP access';
+
+    public function handle(): int
+    {
+        $identifier = (string) $this->argument('user');
+
+        $user = User::where('id', $identifier)
+            ->orWhere('email', $identifier)
+            ->first();
+
+        if (! $user) {
+            $this->error("User [{$identifier}] not found.");
+
+            return self::FAILURE;
+        }
+
+        $token = $user->createToken((string) $this->option('name'));
+
+        $this->info("Token for {$user->email}:");
+        $this->line($token->plainTextToken);
+        $this->newLine();
+        $this->comment('Store it now — it will not be shown again.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Settings/McpTokenController.php
+++ b/app/Http/Controllers/Settings/McpTokenController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class McpTokenController extends Controller
+{
+    /**
+     * Show the MCP tokens settings page.
+     */
+    public function index(Request $request): Response
+    {
+        return Inertia::render('settings/mcp-tokens', [
+            'tokens' => $request->user()->tokens()
+                ->latest()
+                ->get(['id', 'name', 'last_used_at', 'created_at']),
+            'appUrl' => config('app.url'),
+        ]);
+    }
+
+    /**
+     * Create a new personal access token.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+        ]);
+
+        $token = $request->user()->createToken($validated['name']);
+
+        return back()->with('mcpToken', $token->plainTextToken);
+    }
+
+    /**
+     * Revoke a personal access token.
+     */
+    public function destroy(Request $request, string $token): RedirectResponse
+    {
+        $deleted = $request->user()->tokens()->where('id', $token)->delete();
+
+        abort_if($deleted === 0, 404);
+
+        return back();
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -96,6 +96,9 @@ class HandleInertiaRequests extends Middleware
             'period' => fn () => $request->query('period', '1h'),
             'from' => fn () => $request->query('from'),
             'to' => fn () => $request->query('to'),
+            'flash' => [
+                'mcpToken' => fn () => $request->session()->get('mcpToken'),
+            ],
         ];
     }
 }

--- a/app/Mcp/Concerns/ResolvesAccessibleProjects.php
+++ b/app/Mcp/Concerns/ResolvesAccessibleProjects.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Mcp\Concerns;
+
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+
+trait ResolvesAccessibleProjects
+{
+    /**
+     * Projects belonging to any team the user is a member of.
+     */
+    protected function accessibleProjects(User $user): Builder
+    {
+        return Project::whereIn('team_id', $user->teams()->pluck('teams.id'));
+    }
+
+    /**
+     * Resolve an accessible project by its slug.
+     */
+    protected function resolveAccessibleProject(User $user, string $slug): ?Project
+    {
+        return $this->accessibleProjects($user)->where('slug', $slug)->first();
+    }
+}

--- a/app/Mcp/Servers/LaraowlServer.php
+++ b/app/Mcp/Servers/LaraowlServer.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Mcp\Servers;
+
+use App\Mcp\Tools\CommentOnIssue;
+use App\Mcp\Tools\GetIssue;
+use App\Mcp\Tools\ListIssues;
+use App\Mcp\Tools\ListProjects;
+use App\Mcp\Tools\QueryTelemetry;
+use App\Mcp\Tools\UpdateIssueStatus;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Attributes\Instructions;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Attributes\Version;
+
+#[Name('laraowl')]
+#[Version('0.1.0')]
+#[Instructions('Browse laraowl projects, issues, and telemetry, and triage issues by updating status or adding comments. All data is scoped to the authenticated user\'s teams.')]
+class LaraowlServer extends Server
+{
+    protected array $tools = [
+        ListProjects::class,
+        ListIssues::class,
+        GetIssue::class,
+        QueryTelemetry::class,
+        UpdateIssueStatus::class,
+        CommentOnIssue::class,
+    ];
+}

--- a/app/Mcp/Support/PayloadSanitizer.php
+++ b/app/Mcp/Support/PayloadSanitizer.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Mcp\Support;
+
+use Illuminate\Support\Str;
+
+class PayloadSanitizer
+{
+    /**
+     * Redact denylisted keys and truncate long strings in a record payload.
+     *
+     * @param  array<array-key, mixed>  $payload
+     * @return array<array-key, mixed>
+     */
+    public static function sanitize(array $payload): array
+    {
+        /** @var array<int, string> $keys */
+        $keys = config('laraowl-mcp.redaction.keys', []);
+        $maxLength = (int) config('laraowl-mcp.redaction.max_length', 2000);
+
+        return self::walk($payload, $keys, $maxLength);
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $data
+     * @param  array<int, string>  $keys
+     * @return array<array-key, mixed>
+     */
+    private static function walk(array $data, array $keys, int $maxLength): array
+    {
+        foreach ($data as $key => $value) {
+            if (is_string($key) && in_array(strtolower($key), $keys, true)) {
+                $data[$key] = '[REDACTED]';
+
+                continue;
+            }
+
+            if (is_array($value)) {
+                $data[$key] = self::walk($value, $keys, $maxLength);
+            } elseif (is_string($value)) {
+                $data[$key] = Str::limit($value, $maxLength);
+            }
+        }
+
+        return $data;
+    }
+}

--- a/app/Mcp/Tools/CommentOnIssue.php
+++ b/app/Mcp/Tools/CommentOnIssue.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Mcp\Concerns\ResolvesAccessibleProjects;
+use App\Models\Issue;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+
+#[Description('Add a comment to an issue. The comment is recorded in the issue activity timeline, attributed to the current user.')]
+class CommentOnIssue extends Tool
+{
+    use ResolvesAccessibleProjects;
+
+    public function handle(Request $request): Response
+    {
+        $request->validate([
+            'issue' => ['required', 'integer'],
+            'body' => ['required', 'string', 'max:5000'],
+        ]);
+
+        /** @var User $user */
+        $user = $request->user();
+        $projectIds = $this->accessibleProjects($user)->pluck('id');
+
+        $issue = Issue::whereIn('project_id', $projectIds)
+            ->where('id', $request->get('issue'))
+            ->first();
+
+        if (! $issue instanceof Issue) {
+            return Response::error('Issue not found or not accessible.');
+        }
+
+        $activity = $issue->activities()->create([
+            'user_id' => $user->id,
+            'type' => 'comment',
+            'content' => $request->get('body'),
+        ]);
+
+        return Response::json(['id' => $activity->id, 'issue_id' => $issue->id]);
+    }
+
+    /**
+     * @return array<string, JsonSchema>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'issue' => $schema->integer()->description('The issue id.')->required(),
+            'body' => $schema->string()->description('Comment text.')->required(),
+        ];
+    }
+}

--- a/app/Mcp/Tools/GetIssue.php
+++ b/app/Mcp/Tools/GetIssue.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Mcp\Concerns\ResolvesAccessibleProjects;
+use App\Mcp\Support\PayloadSanitizer;
+use App\Models\Issue;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+
+#[Description('Get full detail for one issue: the issue, its recent records (stack traces / payloads), and its activity timeline.')]
+class GetIssue extends Tool
+{
+    use ResolvesAccessibleProjects;
+
+    public function handle(Request $request): Response
+    {
+        $request->validate(['issue' => ['required', 'integer']]);
+
+        /** @var User $user */
+        $user = $request->user();
+        $projectIds = $this->accessibleProjects($user)->pluck('id');
+
+        $issue = Issue::whereIn('project_id', $projectIds)
+            ->where('id', $request->get('issue'))
+            ->first();
+
+        if (! $issue instanceof Issue) {
+            return Response::error('Issue not found or not accessible.');
+        }
+
+        $records = $issue->records()
+            ->orderByDesc('created_at')
+            ->limit(20)
+            ->get(['id', 'type', 'payload', 'created_at'])
+            ->map(fn ($record) => [
+                'id' => $record->id,
+                'type' => $record->type,
+                'created_at' => $record->created_at,
+                'payload' => PayloadSanitizer::sanitize((array) $record->payload),
+            ]);
+
+        $activities = $issue->activities()
+            ->orderBy('created_at')
+            ->get(['id', 'user_id', 'type', 'content', 'created_at']);
+
+        return Response::json([
+            'issue' => $issue->only(['id', 'project_id', 'type', 'title', 'message', 'status', 'priority', 'occurrences_count', 'users_count', 'first_seen_at', 'last_seen_at']),
+            'records' => $records,
+            'activities' => $activities,
+        ]);
+    }
+
+    /**
+     * @return array<string, JsonSchema>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'issue' => $schema->integer()->description('The issue id.')->required(),
+        ];
+    }
+}

--- a/app/Mcp/Tools/ListIssues.php
+++ b/app/Mcp/Tools/ListIssues.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Mcp\Concerns\ResolvesAccessibleProjects;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+
+#[Description('List issues for a project, most recently seen first. Optionally filter by status.')]
+class ListIssues extends Tool
+{
+    use ResolvesAccessibleProjects;
+
+    public function handle(Request $request): Response
+    {
+        $request->validate([
+            'project' => ['required'],
+            'status' => ['nullable', 'in:open,resolved,ignored'],
+            'limit' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        /** @var User $user */
+        $user = $request->user();
+        $identifier = $request->get('project');
+
+        $project = $this->resolveAccessibleProject($user, $identifier);
+
+        if (! $project instanceof Project) {
+            return Response::error("Project [{$identifier}] not found or not accessible.");
+        }
+
+        $issues = $project->issues()
+            ->when($request->get('status'), fn ($q, $status) => $q->where('status', $status))
+            ->orderByDesc('last_seen_at')
+            ->limit((int) $request->get('limit', 25))
+            ->get(['id', 'type', 'title', 'status', 'priority', 'occurrences_count', 'users_count', 'first_seen_at', 'last_seen_at']);
+
+        return Response::json($issues);
+    }
+
+    /**
+     * @return array<string, JsonSchema>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'project' => $schema->string()->description('Project slug.')->required(),
+            'status' => $schema->string()->description('Filter: open, resolved, or ignored.')->enum(['open', 'resolved', 'ignored']),
+            'limit' => $schema->integer()->description('Max issues to return (1-100).')->default(25),
+        ];
+    }
+}

--- a/app/Mcp/Tools/ListProjects.php
+++ b/app/Mcp/Tools/ListProjects.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Mcp\Concerns\ResolvesAccessibleProjects;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+
+#[Description('List the projects (monitored applications) the current user can access, across all their teams.')]
+class ListProjects extends Tool
+{
+    use ResolvesAccessibleProjects;
+
+    public function handle(Request $request): Response
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        $projects = $this->accessibleProjects($user)
+            ->get(['team_id', 'name', 'slug'])
+            ->map(fn ($project) => [
+                'team_id' => $project->team_id,
+                'name' => $project->name,
+                'slug' => $project->slug,
+            ]);
+
+        return Response::json($projects);
+    }
+
+    /**
+     * @return array<string, JsonSchema>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}

--- a/app/Mcp/Tools/QueryTelemetry.php
+++ b/app/Mcp/Tools/QueryTelemetry.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Mcp\Concerns\ResolvesAccessibleProjects;
+use App\Mcp\Support\PayloadSanitizer;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+
+#[Description('Query raw telemetry records (requests, queries, jobs, commands, mail, cache, etc.) for a project over a time period. Use this to debug non-exception behaviour like slow endpoints or failing jobs.')]
+class QueryTelemetry extends Tool
+{
+    use ResolvesAccessibleProjects;
+
+    public function handle(Request $request): Response
+    {
+        $request->validate([
+            'project' => ['required'],
+            'type' => ['required', 'string'],
+            'period' => ['nullable', 'in:1h,24h,custom'],
+            'from' => ['nullable', 'date'],
+            'to' => ['nullable', 'date'],
+            'limit' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        /** @var User $user */
+        $user = $request->user();
+        $identifier = $request->get('project');
+
+        $project = $this->resolveAccessibleProject($user, $identifier);
+
+        if (! $project instanceof Project) {
+            return Response::error("Project [{$identifier}] not found or not accessible.");
+        }
+
+        $records = $project->records()
+            ->ofType($request->get('type'))
+            ->forPeriod($request->get('period', '24h'), $request->get('from'), $request->get('to'))
+            ->orderByDesc('created_at')
+            ->limit((int) $request->get('limit', 25))
+            ->get(['id', 'type', 'payload', 'created_at'])
+            ->map(fn ($record) => [
+                'id' => $record->id,
+                'type' => $record->type,
+                'created_at' => $record->created_at,
+                'payload' => PayloadSanitizer::sanitize((array) $record->payload),
+            ]);
+
+        return Response::json($records);
+    }
+
+    /**
+     * @return array<string, JsonSchema>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'project' => $schema->string()->description('Project slug.')->required(),
+            'type' => $schema->string()->description('Record type: request, exception, query, command, job-attempt, queued-job, scheduled-task, mail, cache, notification, outgoing-request.')->required(),
+            'period' => $schema->string()->description('Time window: 1h, 24h, or custom (with from/to).')->enum(['1h', '24h', 'custom'])->default('24h'),
+            'from' => $schema->string()->description('ISO start time when period=custom.'),
+            'to' => $schema->string()->description('ISO end time when period=custom.'),
+            'limit' => $schema->integer()->description('Max records (1-100).')->default(25),
+        ];
+    }
+}

--- a/app/Mcp/Tools/UpdateIssueStatus.php
+++ b/app/Mcp/Tools/UpdateIssueStatus.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Mcp\Concerns\ResolvesAccessibleProjects;
+use App\Models\Issue;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+
+#[Description('Update an issue\'s status (open, resolved, ignored). The change is logged to the issue activity timeline, attributed to the current user.')]
+class UpdateIssueStatus extends Tool
+{
+    use ResolvesAccessibleProjects;
+
+    public function handle(Request $request): Response
+    {
+        $request->validate([
+            'issue' => ['required', 'integer'],
+            'status' => ['required', 'in:open,resolved,ignored'],
+        ]);
+
+        /** @var User $user */
+        $user = $request->user();
+        $projectIds = $this->accessibleProjects($user)->pluck('id');
+
+        $issue = Issue::whereIn('project_id', $projectIds)
+            ->where('id', $request->get('issue'))
+            ->first();
+
+        if (! $issue instanceof Issue) {
+            return Response::error('Issue not found or not accessible.');
+        }
+
+        $from = $issue->status;
+        $to = $request->get('status');
+
+        if ($from !== $to) {
+            $issue->update(['status' => $to]);
+
+            $issue->activities()->create([
+                'user_id' => $user->id,
+                'type' => 'status_change',
+                'content' => "Status changed from {$from} to {$to}.",
+                'metadata' => ['from' => $from, 'to' => $to],
+            ]);
+        }
+
+        return Response::json(['id' => $issue->id, 'status' => $to]);
+    }
+
+    /**
+     * @return array<string, JsonSchema>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'issue' => $schema->integer()->description('The issue id.')->required(),
+            'status' => $schema->string()->description('New status.')->enum(['open', 'resolved', 'ignored'])->required(),
+        ];
+    }
+}

--- a/app/Models/Record.php
+++ b/app/Models/Record.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,7 +10,7 @@ use Illuminate\Support\Facades\DB;
 
 class Record extends Model
 {
-    use MassPrunable;
+    use HasFactory, MassPrunable;
 
     public $timestamps = false;
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -11,13 +11,14 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
+use Laravel\Sanctum\HasApiTokens;
 
 #[Fillable(['name', 'email', 'password', 'current_team_id'])]
 #[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token'])]
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, HasTeams, Notifiable, TwoFactorAuthenticatable;
+    use HasApiTokens, HasFactory, HasTeams, Notifiable, TwoFactorAuthenticatable;
 
     /**
      * Get the attributes that should be cast.

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "laravel/fortify": "^1.34",
         "laravel/framework": "^13.7",
         "laravel/horizon": "^5.47",
+        "laravel/mcp": "^0.7.0",
         "laravel/reverb": "^1.0",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a9f6307f01f4fa53e5d0b6a17ad20d16",
+    "content-hash": "b04900b35a691eb81389a3bae51e9a80",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -1900,6 +1900,80 @@
                 "source": "https://github.com/laravel/horizon/tree/v5.47.2"
             },
             "time": "2026-06-03T15:11:37+00:00"
+        },
+        {
+            "name": "laravel/mcp",
+            "version": "v0.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/mcp.git",
+                "reference": "08962a276357f89164f78b38407c08187ab26cfe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/mcp/zipball/08962a276357f89164f78b38407c08187ab26cfe",
+                "reference": "08962a276357f89164f78b38407c08187ab26cfe",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "illuminate/console": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/container": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/contracts": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/http": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/json-schema": "^12.41.1|^13.0",
+                "illuminate/routing": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/support": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/validation": "^11.45.3|^12.41.1|^13.0",
+                "php": "^8.2",
+                "symfony/process": "^7.4.5|^8.0.5"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.20",
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "pestphp/pest": "^3.8.5|^4.3.2",
+                "phpstan/phpstan": "^2.1.27",
+                "rector/rector": "^2.2.4"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Mcp": "Laravel\\Mcp\\Server\\Facades\\Mcp"
+                    },
+                    "providers": [
+                        "Laravel\\Mcp\\Server\\McpServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Mcp\\": "src/",
+                    "Laravel\\Mcp\\Server\\": "src/Server/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Rapidly build MCP servers for your Laravel applications.",
+            "homepage": "https://github.com/laravel/mcp",
+            "keywords": [
+                "laravel",
+                "mcp"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/mcp/issues",
+                "source": "https://github.com/laravel/mcp"
+            },
+            "time": "2026-05-22T11:45:29+00:00"
         },
         {
             "name": "laravel/passkeys",
@@ -10005,79 +10079,6 @@
                 "source": "https://github.com/laravel/boost"
             },
             "time": "2026-04-28T11:52:01+00:00"
-        },
-        {
-            "name": "laravel/mcp",
-            "version": "v0.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laravel/mcp.git",
-                "reference": "3513b4feca5f1678be4d2261dcfa8e456436d02a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laravel/mcp/zipball/3513b4feca5f1678be4d2261dcfa8e456436d02a",
-                "reference": "3513b4feca5f1678be4d2261dcfa8e456436d02a",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "ext-mbstring": "*",
-                "illuminate/console": "^11.45.3|^12.41.1|^13.0",
-                "illuminate/container": "^11.45.3|^12.41.1|^13.0",
-                "illuminate/contracts": "^11.45.3|^12.41.1|^13.0",
-                "illuminate/http": "^11.45.3|^12.41.1|^13.0",
-                "illuminate/json-schema": "^12.41.1|^13.0",
-                "illuminate/routing": "^11.45.3|^12.41.1|^13.0",
-                "illuminate/support": "^11.45.3|^12.41.1|^13.0",
-                "illuminate/validation": "^11.45.3|^12.41.1|^13.0",
-                "php": "^8.2"
-            },
-            "require-dev": {
-                "laravel/pint": "^1.20",
-                "orchestra/testbench": "^9.15|^10.8|^11.0",
-                "pestphp/pest": "^3.8.5|^4.3.2",
-                "phpstan/phpstan": "^2.1.27",
-                "rector/rector": "^2.2.4"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "aliases": {
-                        "Mcp": "Laravel\\Mcp\\Server\\Facades\\Mcp"
-                    },
-                    "providers": [
-                        "Laravel\\Mcp\\Server\\McpServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laravel\\Mcp\\": "src/",
-                    "Laravel\\Mcp\\Server\\": "src/Server/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
-                }
-            ],
-            "description": "Rapidly build MCP servers for your Laravel applications.",
-            "homepage": "https://github.com/laravel/mcp",
-            "keywords": [
-                "laravel",
-                "mcp"
-            ],
-            "support": {
-                "issues": "https://github.com/laravel/mcp/issues",
-                "source": "https://github.com/laravel/mcp"
-            },
-            "time": "2026-04-21T10:23:03+00:00"
         },
         {
             "name": "laravel/pail",

--- a/config/laraowl-mcp.php
+++ b/config/laraowl-mcp.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'redaction' => [
+        'keys' => [
+            'authorization', 'cookie', 'set-cookie', 'password',
+            'password_confirmation', 'token', 'secret', 'api_key',
+            'apikey', 'access_token', 'refresh_token', 'php_auth_pw',
+        ],
+        'max_length' => 2000,
+    ],
+];

--- a/database/factories/RecordFactory.php
+++ b/database/factories/RecordFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Project;
+use App\Models\Record;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class RecordFactory extends Factory
+{
+    protected $model = Record::class;
+
+    public function definition(): array
+    {
+        return [
+            'project_id' => Project::factory(),
+            'issue_id' => null,
+            'type' => 'request',
+            'payload' => ['t' => 'request', 'method' => 'GET', 'path' => '/'],
+            'fingerprint' => $this->faker->sha1(),
+            'created_at' => now(),
+        ];
+    }
+}

--- a/resources/js/layouts/settings/layout.tsx
+++ b/resources/js/layouts/settings/layout.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { useCurrentUrl } from '@/hooks/use-current-url';
 import { cn, toUrl } from '@/lib/utils';
+import { index as mcpTokens } from '@/routes/mcp-tokens';
 import { edit } from '@/routes/profile';
 import { edit as editSecurity } from '@/routes/security';
 import { index as teams } from '@/routes/teams';
@@ -24,6 +25,11 @@ const sidebarNavItems: NavItem[] = [
     {
         title: 'Teams',
         href: teams(),
+        icon: null,
+    },
+    {
+        title: 'MCP Tokens',
+        href: mcpTokens(),
         icon: null,
     },
 ];

--- a/resources/js/pages/settings/mcp-tokens.tsx
+++ b/resources/js/pages/settings/mcp-tokens.tsx
@@ -1,0 +1,141 @@
+import { Form, Head, usePage } from '@inertiajs/react';
+
+import McpTokenController from '@/actions/App/Http/Controllers/Settings/McpTokenController';
+import Heading from '@/components/heading';
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { index as mcpTokens } from '@/routes/mcp-tokens';
+import type { SharedData } from '@/types';
+
+type Token = {
+    id: number;
+    name: string;
+    last_used_at: string | null;
+    created_at: string;
+};
+
+type Flash = {
+    mcpToken?: string | null;
+};
+
+export default function McpTokens({
+    tokens,
+    appUrl,
+}: {
+    tokens: Token[];
+    appUrl: string;
+}) {
+    const { flash } = usePage<SharedData & { flash: Flash }>().props;
+
+    return (
+        <>
+            <Head title="MCP Tokens" />
+
+            <h1 className="sr-only">MCP Tokens</h1>
+
+            <div className="space-y-6">
+                <Heading
+                    variant="small"
+                    title="MCP Tokens"
+                    description="Personal access tokens for connecting AI agents to laraowl over MCP."
+                />
+
+                {flash?.mcpToken && (
+                    <div className="rounded-lg border border-border bg-muted/30 p-3">
+                        <p className="text-sm font-semibold">
+                            Copy this token now — it won&apos;t be shown again.
+                        </p>
+                        <code className="mt-2 block break-all text-xs">
+                            {flash.mcpToken}
+                        </code>
+                        <p className="mt-3 text-xs text-muted-foreground">
+                            Connect snippet:
+                        </p>
+                        <code className="mt-1 block break-all text-xs">
+                            {`claude mcp add --transport http laraowl ${appUrl}/mcp --header "Authorization: Bearer ${flash.mcpToken}"`}
+                        </code>
+                    </div>
+                )}
+
+                <Form
+                    {...McpTokenController.store.form()}
+                    options={{ preserveScroll: true }}
+                    resetOnSuccess
+                    className="space-y-4"
+                >
+                    {({ processing, errors }) => (
+                        <>
+                            <div className="grid gap-2">
+                                <Label htmlFor="name">Token name</Label>
+
+                                <Input
+                                    id="name"
+                                    name="name"
+                                    placeholder="My laptop"
+                                />
+
+                                <InputError message={errors.name} />
+                            </div>
+
+                            <Button type="submit" disabled={processing}>
+                                Create token
+                            </Button>
+                        </>
+                    )}
+                </Form>
+
+                {tokens.length > 0 && (
+                    <ul className="divide-y divide-border">
+                        {tokens.map((token) => (
+                            <li
+                                key={token.id}
+                                className="flex items-center justify-between py-2"
+                            >
+                                <div>
+                                    <span className="text-sm">{token.name}</span>
+                                    {token.last_used_at && (
+                                        <span className="ml-2 text-xs text-muted-foreground">
+                                            Last used{' '}
+                                            {new Date(
+                                                token.last_used_at,
+                                            ).toLocaleDateString()}
+                                        </span>
+                                    )}
+                                </div>
+
+                                <Form
+                                    {...McpTokenController.destroy.form(
+                                        token.id,
+                                    )}
+                                    options={{ preserveScroll: true }}
+                                >
+                                    {({ processing }) => (
+                                        <Button
+                                            type="submit"
+                                            variant="ghost"
+                                            size="sm"
+                                            disabled={processing}
+                                        >
+                                            Revoke
+                                        </Button>
+                                    )}
+                                </Form>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+        </>
+    );
+}
+
+McpTokens.layout = {
+    breadcrumbs: [
+        {
+            title: 'MCP Tokens',
+            href: mcpTokens(),
+        },
+    ],
+};

--- a/routes/ai.php
+++ b/routes/ai.php
@@ -1,0 +1,6 @@
+<?php
+
+use App\Mcp\Servers\LaraowlServer;
+use Laravel\Mcp\Facades\Mcp;
+
+Mcp::web('/mcp', LaraowlServer::class)->middleware(['auth:sanctum']);

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Settings\McpTokenController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\Settings\SecurityController;
 use App\Http\Controllers\Teams\TeamController;
@@ -25,6 +26,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->name('user-password.update');
 
     Route::inertia('settings/appearance', 'settings/appearance')->name('appearance.edit');
+
+    Route::get('settings/mcp-tokens', [McpTokenController::class, 'index'])->name('mcp-tokens.index');
+    Route::post('settings/mcp-tokens', [McpTokenController::class, 'store'])->name('mcp-tokens.store');
+    Route::delete('settings/mcp-tokens/{token}', [McpTokenController::class, 'destroy'])->name('mcp-tokens.destroy');
 
     Route::middleware(EnsureTeamMembership::class)->group(function () {
         Route::get('settings/teams/{team}', [TeamController::class, 'edit'])->name('teams.edit');

--- a/tests/Feature/Mcp/CommentOnIssueTest.php
+++ b/tests/Feature/Mcp/CommentOnIssueTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Mcp\Servers\LaraowlServer;
+use App\Mcp\Tools\CommentOnIssue;
+use App\Models\Issue;
+use App\Models\IssueActivity;
+use App\Models\Project;
+use App\Models\User;
+
+it('adds an attributed comment activity', function () {
+    $user = User::factory()->create();
+    $project = Project::factory()->for($user->currentTeam)->create();
+    $issue = Issue::create(['project_id' => $project->id, 'hash' => 'h', 'type' => 'exception', 'title' => 'Bug', 'status' => 'open', 'last_seen_at' => now(), 'message' => '']);
+
+    LaraowlServer::actingAs($user)
+        ->tool(CommentOnIssue::class, ['issue' => $issue->id, 'body' => 'Likely a null guard.'])
+        ->assertOk();
+
+    $activity = IssueActivity::where('issue_id', $issue->id)->first();
+    expect($activity->type)->toBe('comment')
+        ->and($activity->user_id)->toBe($user->id)
+        ->and($activity->content)->toBe('Likely a null guard.');
+});
+
+it('cannot comment on an issue outside the user\'s teams', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $project = Project::factory()->for($other->currentTeam)->create();
+    $issue = Issue::create(['project_id' => $project->id, 'hash' => 'h', 'type' => 'exception', 'title' => 'Bug', 'status' => 'open', 'last_seen_at' => now(), 'message' => '']);
+
+    LaraowlServer::actingAs($user)
+        ->tool(CommentOnIssue::class, ['issue' => $issue->id, 'body' => 'hi'])
+        ->assertHasErrors();
+
+    expect(IssueActivity::where('issue_id', $issue->id)->count())->toBe(0);
+});

--- a/tests/Feature/Mcp/GetIssueTest.php
+++ b/tests/Feature/Mcp/GetIssueTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Mcp\Servers\LaraowlServer;
+use App\Mcp\Tools\GetIssue;
+use App\Models\Issue;
+use App\Models\Project;
+use App\Models\Record;
+use App\Models\User;
+
+it('returns issue detail with sanitized record payloads', function () {
+    $user = User::factory()->create();
+    $project = Project::factory()->for($user->currentTeam)->create();
+    $issue = Issue::create(['project_id' => $project->id, 'hash' => 'h', 'type' => 'exception', 'title' => 'Boom', 'message' => '', 'status' => 'open', 'last_seen_at' => now()]);
+
+    Record::factory()->for($project)->create([
+        'issue_id' => $issue->id,
+        'type' => 'exception',
+        'payload' => ['message' => 'Boom', 'authorization' => 'Bearer leak-me'],
+    ]);
+
+    LaraowlServer::actingAs($user)
+        ->tool(GetIssue::class, ['issue' => $issue->id])
+        ->assertOk()
+        ->assertSee('Boom')
+        ->assertSee('[REDACTED]')
+        ->assertDontSee('leak-me');
+});
+
+it('refuses an issue outside the user\'s teams', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $project = Project::factory()->for($other->currentTeam)->create();
+    $issue = Issue::create(['project_id' => $project->id, 'hash' => 'h', 'type' => 'exception', 'title' => 'Secret', 'message' => '', 'status' => 'open', 'last_seen_at' => now()]);
+
+    LaraowlServer::actingAs($user)
+        ->tool(GetIssue::class, ['issue' => $issue->id])
+        ->assertHasErrors();
+});

--- a/tests/Feature/Mcp/IssueMcpTokenTest.php
+++ b/tests/Feature/Mcp/IssueMcpTokenTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use App\Models\User;
+use Laravel\Sanctum\PersonalAccessToken;
+
+it('issues a token for a user by email', function () {
+    $user = User::factory()->create(['email' => 'dev@example.com']);
+
+    $this->artisan('laraowl:mcp-token', ['user' => 'dev@example.com'])
+        ->assertExitCode(0);
+
+    expect(PersonalAccessToken::where('tokenable_id', $user->id)->count())->toBe(1);
+});
+
+it('fails when the user does not exist', function () {
+    $this->artisan('laraowl:mcp-token', ['user' => 'nobody@example.com'])
+        ->assertExitCode(1);
+});

--- a/tests/Feature/Mcp/ListIssuesTest.php
+++ b/tests/Feature/Mcp/ListIssuesTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Mcp\Servers\LaraowlServer;
+use App\Mcp\Tools\ListIssues;
+use App\Models\Issue;
+use App\Models\Project;
+use App\Models\User;
+
+it('lists issues for an accessible project and filters by status', function () {
+    $user = User::factory()->create();
+    $project = Project::factory()->for($user->currentTeam)->create(['slug' => 'shop']);
+
+    Issue::create(['project_id' => $project->id, 'hash' => 'a', 'type' => 'exception', 'title' => 'Open Bug', 'message' => '', 'status' => 'open', 'last_seen_at' => now()]);
+    Issue::create(['project_id' => $project->id, 'hash' => 'b', 'type' => 'exception', 'title' => 'Fixed Bug', 'message' => '', 'status' => 'resolved', 'last_seen_at' => now()]);
+
+    LaraowlServer::actingAs($user)
+        ->tool(ListIssues::class, ['project' => 'shop', 'status' => 'open'])
+        ->assertOk()
+        ->assertSee('Open Bug')
+        ->assertDontSee('Fixed Bug');
+});
+
+it('rejects a project the user cannot access', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    Project::factory()->for($other->currentTeam)->create(['slug' => 'secret']);
+
+    LaraowlServer::actingAs($user)
+        ->tool(ListIssues::class, ['project' => 'secret'])
+        ->assertHasErrors();
+});

--- a/tests/Feature/Mcp/ListProjectsTest.php
+++ b/tests/Feature/Mcp/ListProjectsTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Mcp\Servers\LaraowlServer;
+use App\Mcp\Tools\ListProjects;
+use App\Models\Project;
+use App\Models\User;
+
+it('lists only projects in the user\'s teams', function () {
+    $user = User::factory()->create();
+    $mine = Project::factory()->for($user->currentTeam)->create(['name' => 'Mine']);
+
+    $other = User::factory()->create();
+    Project::factory()->for($other->currentTeam)->create(['name' => 'Theirs']);
+
+    LaraowlServer::actingAs($user)
+        ->tool(ListProjects::class)
+        ->assertOk()
+        ->assertSee('Mine')
+        ->assertDontSee('Theirs');
+});

--- a/tests/Feature/Mcp/PayloadSanitizerTest.php
+++ b/tests/Feature/Mcp/PayloadSanitizerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Mcp\Support\PayloadSanitizer;
+
+it('redacts denylisted keys at any depth', function () {
+    $clean = PayloadSanitizer::sanitize([
+        'method' => 'GET',
+        'headers' => [
+            'Authorization' => 'Bearer secret-token',
+            'Cookie' => 'session=abc',
+            'Accept' => 'application/json',
+        ],
+        'password' => 'hunter2',
+    ]);
+
+    expect($clean['method'])->toBe('GET')
+        ->and($clean['headers']['Authorization'])->toBe('[REDACTED]')
+        ->and($clean['headers']['Cookie'])->toBe('[REDACTED]')
+        ->and($clean['headers']['Accept'])->toBe('application/json')
+        ->and($clean['password'])->toBe('[REDACTED]');
+});
+
+it('truncates long string values', function () {
+    $long = str_repeat('x', 5000);
+
+    $clean = PayloadSanitizer::sanitize(['sql' => $long]);
+
+    expect(strlen($clean['sql']))->toBeLessThan(2100)
+        ->and($clean['sql'])->toEndWith('...');
+});

--- a/tests/Feature/Mcp/QueryTelemetryTest.php
+++ b/tests/Feature/Mcp/QueryTelemetryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Mcp\Servers\LaraowlServer;
+use App\Mcp\Tools\QueryTelemetry;
+use App\Models\Project;
+use App\Models\Record;
+use App\Models\User;
+
+it('returns recent records of a type for an accessible project, sanitized', function () {
+    $user = User::factory()->create();
+    $project = Project::factory()->for($user->currentTeam)->create(['slug' => 'api']);
+
+    Record::factory()->for($project)->create([
+        'type' => 'request',
+        'payload' => ['method' => 'POST', 'path' => '/login', 'password' => 'hunter2'],
+        'created_at' => now(),
+    ]);
+    Record::factory()->for($project)->create(['type' => 'query', 'payload' => ['sql' => 'select 1'], 'created_at' => now()]);
+
+    LaraowlServer::actingAs($user)
+        ->tool(QueryTelemetry::class, ['project' => 'api', 'type' => 'request'])
+        ->assertOk()
+        ->assertSee('/login')
+        ->assertSee('[REDACTED]')
+        ->assertDontSee('hunter2')
+        ->assertDontSee('select 1');
+});
+
+it('refuses telemetry for an inaccessible project', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    Project::factory()->for($other->currentTeam)->create(['slug' => 'private']);
+
+    LaraowlServer::actingAs($user)
+        ->tool(QueryTelemetry::class, ['project' => 'private', 'type' => 'request'])
+        ->assertHasErrors();
+});

--- a/tests/Feature/Mcp/UpdateIssueStatusTest.php
+++ b/tests/Feature/Mcp/UpdateIssueStatusTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Mcp\Servers\LaraowlServer;
+use App\Mcp\Tools\UpdateIssueStatus;
+use App\Models\Issue;
+use App\Models\IssueActivity;
+use App\Models\Project;
+use App\Models\User;
+
+it('updates status and logs an attributed activity', function () {
+    $user = User::factory()->create();
+    $project = Project::factory()->for($user->currentTeam)->create();
+    $issue = Issue::create(['project_id' => $project->id, 'hash' => 'h', 'type' => 'exception', 'title' => 'Bug', 'status' => 'open', 'last_seen_at' => now(), 'message' => '']);
+
+    LaraowlServer::actingAs($user)
+        ->tool(UpdateIssueStatus::class, ['issue' => $issue->id, 'status' => 'resolved'])
+        ->assertOk();
+
+    expect($issue->fresh()->status)->toBe('resolved');
+
+    $activity = IssueActivity::where('issue_id', $issue->id)->first();
+    expect($activity->type)->toBe('status_change')
+        ->and($activity->user_id)->toBe($user->id)
+        ->and($activity->metadata['from'])->toBe('open')
+        ->and($activity->metadata['to'])->toBe('resolved');
+});
+
+it('cannot update an issue outside the user\'s teams', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $project = Project::factory()->for($other->currentTeam)->create();
+    $issue = Issue::create(['project_id' => $project->id, 'hash' => 'h', 'type' => 'exception', 'title' => 'Bug', 'status' => 'open', 'last_seen_at' => now(), 'message' => '']);
+
+    LaraowlServer::actingAs($user)
+        ->tool(UpdateIssueStatus::class, ['issue' => $issue->id, 'status' => 'resolved'])
+        ->assertHasErrors();
+
+    expect($issue->fresh()->status)->toBe('open');
+});

--- a/tests/Feature/Settings/McpTokenTest.php
+++ b/tests/Feature/Settings/McpTokenTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\User;
+
+it('creates a token and flashes the plaintext once', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->post('/settings/mcp-tokens', ['name' => 'laptop']);
+
+    $response->assertRedirect();
+    expect($user->tokens()->count())->toBe(1);
+    $response->assertSessionHas('mcpToken');
+});
+
+it('revokes a token', function () {
+    $user = User::factory()->create();
+    $token = $user->createToken('laptop')->accessToken;
+
+    $this->actingAs($user)->delete("/settings/mcp-tokens/{$token->id}")->assertRedirect();
+
+    expect($user->tokens()->count())->toBe(0);
+});
+
+it('cannot revoke another user\'s token', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $token = $other->createToken('laptop')->accessToken;
+
+    $this->actingAs($user)->delete("/settings/mcp-tokens/{$token->id}")->assertNotFound();
+
+    expect($other->tokens()->count())->toBe(1);
+});


### PR DESCRIPTION
Exposes Laraowl over the Model Context Protocol so an AI agent can read
projects, triage issues and query telemetry on the user's behalf. Every
tool is scoped to the authenticated user's teams, and record output is run
through a sanitizer to keep sensitive payload fields out of responses.

The server is served at `POST /mcp` behind `auth:sanctum`.

Generate a token either from **Settings → MCP Tokens**, or via artisan:

    php artisan laraowl:mcp-token user@example.com --name=mcp

Then point your coding agent at the server. For Claude Code:

    claude mcp add --transport http laraowl https://laraowl.test/mcp \
      --header "Authorization: Bearer <token>"

Tools: `list-projects`, `list-issues`, `get-issue`, `query-telemetry`,
`update-issue-status`, `comment-on-issue`.
