### PR TITLE
feat: pre-aggregated rollups, full-text log search, and tenant isolation

### DIFF
--- a/app/Concerns/PrunesByRollupRetention.php
+++ b/app/Concerns/PrunesByRollupRetention.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Concerns;
+
+use App\Models\Project;
+use Illuminate\Database\Eloquent\Builder;
+
+trait PrunesByRollupRetention
+{
+    public function prunableByRollupRetention(): Builder
+    {
+        $projects = Project::query()
+            ->where('rollup_retention_days', '>', 0)
+            ->get(['id', 'rollup_retention_days']);
+
+        if ($projects->isEmpty()) {
+            return static::query()->whereRaw('1 = 0');
+        }
+
+        return static::query()->where(function (Builder $query) use ($projects) {
+            foreach ($projects as $project) {
+                $query->orWhere(function (Builder $builder) use ($project) {
+                    $builder->where('project_id', $project->id)
+                        ->where('bucket', '<', now()->subDays($project->rollup_retention_days));
+                });
+            }
+        });
+    }
+}

--- a/app/Console/Commands/BackfillRollups.php
+++ b/app/Console/Commands/BackfillRollups.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Project;
+use App\Models\Record;
+use App\Models\RecordGroupRollup;
+use App\Models\RecordGroupUserBucket;
+use App\Models\RecordIpBucket;
+use App\Models\RecordRollup;
+use App\Models\RecordUserBucket;
+use App\Services\RollupWriter;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class BackfillRollups extends Command
+{
+    protected $signature = 'laraowl:rollups:backfill
+                            {--project= : Restrict the rebuild to one project id or slug}
+                            {--missing : Only rebuild projects that have records but no rollups yet}
+                            {--since= : Only rebuild buckets at or after this datetime}
+                            {--until= : Only rebuild buckets before this datetime}
+                            {--chunk=2000 : Raw records read per batch}';
+
+    protected $description = 'Rebuild the dashboard rollups from raw records';
+
+    protected const UPDATE_BATCH = 500;
+
+    public function handle(RollupWriter $rollupWriter): int
+    {
+        $projects = $this->targetProjects();
+
+        if ($projects->isEmpty()) {
+            if ($this->option('missing')) {
+                $this->info('Every project already has rollups.');
+
+                return self::SUCCESS;
+            }
+
+            $this->error('No matching projects.');
+
+            return self::FAILURE;
+        }
+
+        $since = $this->option('since');
+        $until = $this->option('until');
+        $chunkSize = max(1, (int) $this->option('chunk'));
+
+        foreach ($projects as $project) {
+            $this->rebuild($project, $rollupWriter, $since, $until, $chunkSize);
+        }
+
+        $this->newLine();
+        $this->info('Rollups rebuilt.');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return Collection<int, Project>
+     */
+    protected function targetProjects(): Collection
+    {
+        $identifier = $this->option('project');
+
+        if ($identifier) {
+            return Project::query()
+                ->where('id', $identifier)
+                ->orWhere('slug', $identifier)
+                ->get();
+        }
+
+        if ($this->option('missing')) {
+            return Project::query()
+                ->whereHas('records')
+                ->whereDoesntHave('rollups')
+                ->get();
+        }
+
+        return Project::all();
+    }
+
+    protected function rebuild(Project $project, RollupWriter $rollupWriter, ?string $since, ?string $until, int $chunkSize): void
+    {
+        $this->newLine();
+        $this->info("Rebuilding {$project->slug}");
+
+        $this->discardExistingRollups($project, $since, $until);
+
+        $total = $this->recordsQuery($project, $since, $until)->count();
+
+        if ($total === 0) {
+            $this->line('  no records in range');
+
+            return;
+        }
+
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
+
+        $this->recordsQuery($project, $since, $until)
+            ->chunkById($chunkSize, function (Collection $chunk) use ($project, $rollupWriter, $bar) {
+                $batch = $chunk->map(fn (Record $record) => [
+                    'type' => $record->type,
+                    'payload' => $record->payload ?? [],
+                    'fingerprint' => $record->fingerprint,
+                    'created_at' => $record->created_at,
+                ])->all();
+
+                $rollupWriter->record($project, $batch);
+                $this->backfillRecordColumns($chunk, $rollupWriter);
+
+                $bar->advance($chunk->count());
+            });
+
+        $bar->finish();
+        $this->newLine();
+    }
+
+    /**
+     * @param  Collection<int, Record>  $chunk
+     */
+    protected function backfillRecordColumns(Collection $chunk, RollupWriter $rollupWriter): void
+    {
+        $updates = $chunk
+            ->map(fn (Record $record) => [
+                'id' => $record->id,
+                'user_key' => $rollupWriter->rawUserKeyFor($record->payload ?? []),
+                'ip' => $rollupWriter->ipFor($record->payload ?? []),
+                'trace_id' => $rollupWriter->traceIdFor($record->payload ?? []),
+                'message' => $rollupWriter->messageFor($record->type, $record->payload ?? []),
+            ])
+            ->filter(fn (array $row) => $row['user_key'] !== null || $row['ip'] !== null || $row['trace_id'] !== null || $row['message'] !== null);
+
+        foreach ($updates->chunk(static::UPDATE_BATCH) as $batch) {
+            $this->updateRecordColumns($batch->values());
+        }
+    }
+
+    /**
+     * @param  Collection<int, array{id: int, user_key: string|null, ip: string|null, trace_id: string|null, message: string|null}>  $rows
+     */
+    protected function updateRecordColumns(Collection $rows): void
+    {
+        if ($rows->isEmpty()) {
+            return;
+        }
+
+        $grammar = DB::connection()->getQueryGrammar();
+        $bindings = [];
+        $cases = [];
+
+        foreach (['user_key', 'ip', 'trace_id', 'message'] as $column) {
+            $when = '';
+            foreach ($rows as $row) {
+                $when .= ' when ? then ?';
+                $bindings[] = $row['id'];
+                $bindings[] = $row[$column];
+            }
+            $cases[] = $grammar->wrap($column).' = case '.$grammar->wrap('id').$when.' end';
+        }
+
+        $ids = $rows->pluck('id')->all();
+        $placeholders = implode(', ', array_fill(0, count($ids), '?'));
+
+        DB::update(
+            'update '.$grammar->wrap('records').' set '.implode(', ', $cases)
+                .' where '.$grammar->wrap('id')." in ({$placeholders})",
+            array_merge($bindings, $ids),
+        );
+    }
+
+    /**
+     * Clear the range being rebuilt, so a re-run cannot accumulate.
+     */
+    protected function discardExistingRollups(Project $project, ?string $since, ?string $until): void
+    {
+        $tables = [
+            RecordRollup::query(),
+            RecordGroupRollup::query(),
+            RecordUserBucket::query(),
+            RecordGroupUserBucket::query(),
+            RecordIpBucket::query(),
+        ];
+
+        foreach ($tables as $query) {
+            $query->where('project_id', $project->id)
+                ->when($since, fn (Builder $builder) => $builder->where('bucket', '>=', $since))
+                ->when($until, fn (Builder $builder) => $builder->where('bucket', '<', $until))
+                ->delete();
+        }
+    }
+
+    /**
+     * @return Builder<Record>
+     */
+    protected function recordsQuery(Project $project, ?string $since, ?string $until): Builder
+    {
+        return Record::query()
+            ->where('project_id', $project->id)
+            ->when($since, fn (Builder $builder) => $builder->where('created_at', '>=', $since))
+            ->when($until, fn (Builder $builder) => $builder->where('created_at', '<', $until));
+    }
+}

--- a/app/Console/Commands/UpdateLaraOwl.php
+++ b/app/Console/Commands/UpdateLaraOwl.php
@@ -158,6 +158,7 @@ class UpdateLaraOwl extends Command
             'Installing JS dependencies' => [$this->binary('npm'), 'ci'],
             'Building assets' => [$this->binary('npm'), 'run', 'build'],
             'Running migrations' => [$php, $artisan, 'migrate', '--force'],
+            'Backfilling dashboard rollups' => [$php, $artisan, 'laraowl:rollups:backfill', '--missing', '--no-interaction'],
             'Clearing caches' => [$php, $artisan, 'optimize:clear'],
             'Restarting queue workers' => [$php, $artisan, 'queue:restart'],
         ];

--- a/app/Http/Controllers/Projects/RecordController.php
+++ b/app/Http/Controllers/Projects/RecordController.php
@@ -261,10 +261,27 @@ class RecordController extends Controller
 
     public function showOccurrence(Team $current_team, Project $project, Record $record): Response
     {
+        // The record is bound by global id, so verify it belongs to the project
+        // in the URL — otherwise any member of any team could read another
+        // team's telemetry by guessing record ids.
+        abort_if($record->project_id !== $project->id, 404);
+
         $record->load('issue');
+        $relatedRecords = [];
+        $traceId = $record->trace_id ?? ($record->payload['trace_id'] ?? null);
+
+        if ($traceId) {
+            $relatedRecords = $project->records()
+                ->where('trace_id', $traceId)
+                ->where('id', '!=', $record->id)
+                ->orderBy('created_at')
+                ->limit(200)
+                ->get(['id', 'type', 'payload', 'created_at']);
+        }
 
         return Inertia::render('projects/records/show', [
             'record' => $record,
+            'relatedRecords' => $relatedRecords,
         ]);
     }
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -43,6 +43,8 @@ class Project extends Model implements HasMedia
         'uptime_check_interval',
         'last_uptime_check_at',
         'last_uptime_status',
+        'retention_days',
+        'rollup_retention_days',
         'settings',
     ];
 
@@ -103,6 +105,16 @@ class Project extends Model implements HasMedia
         return $this->hasMany(Record::class);
     }
 
+    public function rollups(): HasMany
+    {
+        return $this->hasMany(RecordRollup::class);
+    }
+
+    public function userBuckets(): HasMany
+    {
+        return $this->hasMany(RecordUserBucket::class);
+    }
+
     public function issues(): HasMany
     {
         return $this->hasMany(Issue::class);
@@ -114,6 +126,15 @@ class Project extends Model implements HasMedia
     }
 
     public function alertRules(): HasMany
+    {
+        return $this->hasMany(AlertRule::class);
+    }
+
+    /**
+     * Alias of {@see alertRules()} so scoped route binding of the `{rule}`
+     * parameter resolves against this project.
+     */
+    public function rules(): HasMany
     {
         return $this->hasMany(AlertRule::class);
     }

--- a/app/Models/Record.php
+++ b/app/Models/Record.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Model;
@@ -20,6 +21,10 @@ class Record extends Model
         'type',
         'payload',
         'fingerprint',
+        'user_key',
+        'ip',
+        'trace_id',
+        'message',
         'created_at',
     ];
 
@@ -57,13 +62,26 @@ class Record extends Model
             return $query->whereBetween('created_at', [$from, $to]);
         }
 
+        // Floored to the minute so a raw count and the minute-bucketed rollups
+        // cover exactly the same window, which lets the rollups supply a
+        // paginator's total instead of a COUNT(*) over every record.
+        return $query->where('created_at', '>=', static::periodStartsAt($period)->startOfMinute());
+    }
+
+    /**
+     * Resolve a dashboard period into the instant its window opens.
+     *
+     * An unrecognised period must never widen the window: returning the query
+     * unfiltered turned every such call into a full table scan.
+     */
+    public static function periodStartsAt(?string $period): CarbonInterface
+    {
         return match ($period) {
-            '1h' => $query->where('created_at', '>=', now()->subHour()),
-            '24h' => $query->where('created_at', '>=', now()->subDay()),
-            '7d' => $query->where('created_at', '>=', now()->subDays(7)),
-            '14d' => $query->where('created_at', '>=', now()->subDays(14)),
-            '30d' => $query->where('created_at', '>=', now()->subDays(30)),
-            default => $query,
+            '1h' => now()->subHour(),
+            '7d' => now()->subDays(7),
+            '14d' => now()->subDays(14),
+            '30d' => now()->subDays(30),
+            default => now()->subDay(),
         };
     }
 

--- a/app/Models/RecordGroupRollup.php
+++ b/app/Models/RecordGroupRollup.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\PrunesByRollupRetention;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\MassPrunable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class RecordGroupRollup extends Model
+{
+    use MassPrunable, PrunesByRollupRetention;
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'bucket' => 'datetime',
+        'last_seen_at' => 'datetime',
+    ];
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function prunable(): Builder
+    {
+        return $this->prunableByRollupRetention();
+    }
+
+    /**
+     * Limit the query to the hours covered by the requested period.
+     *
+     * @see RecordUserBucket::scopeForPeriod()
+     */
+    public function scopeForPeriod(Builder $query, ?string $period, ?string $from = null, ?string $to = null): Builder
+    {
+        if ($period === 'custom' && $from && $to) {
+            return $query->whereBetween('bucket', [$from, $to]);
+        }
+
+        return $query->where('bucket', '>=', Record::periodStartsAt($period)->startOfHour());
+    }
+}

--- a/app/Models/RecordGroupUserBucket.php
+++ b/app/Models/RecordGroupUserBucket.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\PrunesByRollupRetention;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\MassPrunable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class RecordGroupUserBucket extends Model
+{
+    use MassPrunable, PrunesByRollupRetention;
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'bucket' => 'datetime',
+    ];
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function prunable(): Builder
+    {
+        return $this->prunableByRollupRetention();
+    }
+
+    /**
+     * Limit the query to the hours covered by the requested period.
+     *
+     * @see RecordUserBucket::scopeForPeriod()
+     */
+    public function scopeForPeriod(Builder $query, ?string $period, ?string $from = null, ?string $to = null): Builder
+    {
+        if ($period === 'custom' && $from && $to) {
+            return $query->whereBetween('bucket', [$from, $to]);
+        }
+
+        return $query->where('bucket', '>=', Record::periodStartsAt($period)->startOfHour());
+    }
+}

--- a/app/Models/RecordIpBucket.php
+++ b/app/Models/RecordIpBucket.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\PrunesByRollupRetention;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\MassPrunable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class RecordIpBucket extends Model
+{
+    use MassPrunable, PrunesByRollupRetention;
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'bucket' => 'datetime',
+    ];
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function prunable(): Builder
+    {
+        return $this->prunableByRollupRetention();
+    }
+
+    /**
+     * Limit the query to the hours covered by the requested period.
+     *
+     * @see RecordUserBucket::scopeForPeriod()
+     */
+    public function scopeForPeriod(Builder $query, ?string $period, ?string $from = null, ?string $to = null): Builder
+    {
+        if ($period === 'custom' && $from && $to) {
+            return $query->whereBetween('bucket', [$from, $to]);
+        }
+
+        return $query->where('bucket', '>=', Record::periodStartsAt($period)->startOfHour());
+    }
+}

--- a/app/Models/RecordRollup.php
+++ b/app/Models/RecordRollup.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\PrunesByRollupRetention;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\MassPrunable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class RecordRollup extends Model
+{
+    use MassPrunable, PrunesByRollupRetention;
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'bucket' => 'datetime',
+    ];
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function prunable(): Builder
+    {
+        return $this->prunableByRollupRetention();
+    }
+
+    /**
+     * Limit the query to the buckets covered by the requested period.
+     */
+    public function scopeForPeriod(Builder $query, ?string $period, ?string $from = null, ?string $to = null): Builder
+    {
+        if ($period === 'custom' && $from && $to) {
+            return $query->whereBetween('bucket', [$from, $to]);
+        }
+
+        return $query->where('bucket', '>=', Record::periodStartsAt($period)->startOfMinute());
+    }
+}

--- a/app/Models/RecordUserBucket.php
+++ b/app/Models/RecordUserBucket.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\PrunesByRollupRetention;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\MassPrunable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class RecordUserBucket extends Model
+{
+    use MassPrunable, PrunesByRollupRetention;
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'bucket' => 'datetime',
+    ];
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function prunable(): Builder
+    {
+        return $this->prunableByRollupRetention();
+    }
+
+    /**
+     * Limit the query to the hours covered by the requested period.
+     *
+     * @see RecordRollup::scopeForPeriod()
+     */
+    public function scopeForPeriod(Builder $query, ?string $period, ?string $from = null, ?string $to = null): Builder
+    {
+        if ($period === 'custom' && $from && $to) {
+            return $query->whereBetween('bucket', [$from, $to]);
+        }
+
+        return $query->where('bucket', '>=', Record::periodStartsAt($period)->startOfHour());
+    }
+}

--- a/app/Services/IngestService.php
+++ b/app/Services/IngestService.php
@@ -6,6 +6,7 @@ use App\Events\ProjectDataIngested;
 use App\Models\Issue;
 use App\Models\Project;
 use App\Models\Record;
+use App\Models\Threshold;
 use Illuminate\Support\Facades\DB;
 
 class IngestService
@@ -14,10 +15,20 @@ class IngestService
 
     protected SecurityService $securityService;
 
-    public function __construct(AlertService $alertService, SecurityService $securityService)
+    protected RollupWriter $rollupWriter;
+
+    /**
+     * Cached for the lifetime of one ingest call.
+     *
+     * @var array<string, Threshold>|null
+     */
+    protected ?array $thresholds = null;
+
+    public function __construct(AlertService $alertService, SecurityService $securityService, RollupWriter $rollupWriter)
     {
         $this->alertService = $alertService;
         $this->securityService = $securityService;
+        $this->rollupWriter = $rollupWriter;
     }
 
     /**
@@ -25,20 +36,34 @@ class IngestService
      */
     public function ingest(Project $project, array $records): void
     {
+        $this->thresholds = null;
+
         DB::transaction(function () use ($project, $records) {
+            $batch = [];
+
             foreach ($records as $data) {
                 $type = $data['t'] ?? null;
                 if (! $type) {
                     continue;
                 }
 
-                // The entire $data array is effectively the payload in this flat format
                 $record = $project->records()->create([
                     'type' => $type,
                     'payload' => $data,
                     'fingerprint' => $this->calculateFingerprint($type, $data),
+                    'user_key' => $this->rollupWriter->rawUserKeyFor($data),
+                    'ip' => $this->rollupWriter->ipFor($data),
+                    'trace_id' => $this->rollupWriter->traceIdFor($data),
+                    'message' => $this->rollupWriter->messageFor($type, $data),
                     'created_at' => now(),
                 ]);
+
+                $batch[] = [
+                    'type' => $type,
+                    'payload' => $data,
+                    'fingerprint' => $record->fingerprint,
+                    'created_at' => $record->created_at,
+                ];
 
                 if ($type === 'exception') {
                     $this->handleException($project, $record);
@@ -71,9 +96,9 @@ class IngestService
 
                 $this->checkThresholds($project, $record);
             }
+            $this->rollupWriter->record($project, $batch);
         });
 
-        // Broadcast real-time update to the frontend
         ProjectDataIngested::dispatch($project);
     }
 
@@ -89,7 +114,6 @@ class IngestService
             return;
         }
 
-        // Find applicable thresholds for this project and type
         $thresholdType = match ($record->type) {
             'request' => 'route',
             'job-attempt', 'queued-job' => 'job',
@@ -115,15 +139,28 @@ class IngestService
             return;
         }
 
-        $threshold = $project->thresholds()
-            ->where('type', $thresholdType)
-            ->where('key', $key)
-            ->where('is_enabled', true)
-            ->first();
+        $threshold = $this->enabledThresholds($project)[$thresholdType.'|'.$key] ?? null;
 
-        if ($threshold && $duration > $threshold->value) {
+        // Durations arrive in microseconds; thresholds are authored in
+        // milliseconds (the UI shows "{value}ms"). Without the conversion a
+        // 500ms threshold fired at 500µs — a thousand times too eagerly.
+        if ($threshold && $duration > $threshold->value * 1000) {
             $this->handleSlowPerformance($project, $record, $threshold);
         }
+    }
+
+    /**
+     * The project's enabled thresholds, keyed by type and key.
+     *
+     * @return array<string, Threshold>
+     */
+    protected function enabledThresholds(Project $project): array
+    {
+        return $this->thresholds ??= $project->thresholds()
+            ->where('is_enabled', true)
+            ->get()
+            ->keyBy(fn ($threshold) => $threshold->type.'|'.$threshold->key)
+            ->all();
     }
 
     /**
@@ -133,7 +170,8 @@ class IngestService
     {
         $hash = md5('slow_performance_'.$threshold->type.'_'.$threshold->key);
         $title = 'Slow '.ucfirst($threshold->type).': '.$threshold->key;
-        $message = 'Duration: '.$record->payload['duration'].'ms (Threshold: '.$threshold->value.'ms)';
+        $durationMs = round($record->payload['duration'] / 1000, 2);
+        $message = 'Duration: '.$durationMs.'ms (Threshold: '.$threshold->value.'ms)';
 
         $issue = $project->issues()->firstOrCreate(
             ['hash' => $hash],

--- a/app/Services/RecordService.php
+++ b/app/Services/RecordService.php
@@ -3,8 +3,19 @@
 namespace App\Services;
 
 use App\Models\Project;
+use App\Models\Record;
+use App\Models\RecordGroupRollup;
+use App\Models\RecordGroupUserBucket;
+use App\Models\RecordIpBucket;
+use App\Models\RecordRollup;
+use App\Models\RecordUserBucket;
+use Carbon\Carbon;
 use Cron\CronExpression;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
@@ -16,21 +27,23 @@ class RecordService
     public function getQuickStats(Project $project, ?string $period = null, ?string $from = null, ?string $to = null): array
     {
         $types = ['request', 'exception', 'query', 'queued-job', 'job-attempt', 'scheduled-task', 'cache-event', 'log', 'mail', 'notification', 'outgoing-request'];
+
+        $counts = RecordRollup::query()
+            ->where('project_id', $project->id)
+            ->whereIn('type', $types)
+            ->forPeriod($period, $from, $to)
+            ->select('type', DB::raw('SUM('.$this->col('count').') as total'))
+            ->groupBy('type')
+            ->pluck('total', 'type');
+
         $stats = [];
 
         foreach ($types as $type) {
-            $key = str_replace('-', '_', $type).'s';
-            $count = $project->records()->ofType($type)->forPeriod($period, $from, $to)->count();
-
-            if (isset($stats[$key])) {
-                $stats[$key] += $count;
-            } else {
-                $stats[$key] = $count;
-            }
+            $stats[str_replace('-', '_', $type).'s'] = (int) ($counts[$type] ?? 0);
         }
 
         // Aggregate jobs
-        $stats['jobs'] = ($stats['queued_jobs'] ?? 0) + ($stats['job_attempts'] ?? 0);
+        $stats['jobs'] = $stats['queued_jobs'] + $stats['job_attempts'];
 
         return $stats;
     }
@@ -43,50 +56,31 @@ class RecordService
         $allowedSorts = ['method', 'path', 'total', 'ok_count', 'client_error_count', 'server_error_count', 'avg_duration', 'p95_duration'];
         $sort = in_array($sort, $allowedSorts) ? $sort : 'total';
         $direction = $direction === 'asc' ? 'asc' : 'desc';
-        $statusCode = $this->jsonNumeric('status_code');
-        $duration = $this->jsonNumeric('duration');
-        $method = "COALESCE({$this->jsonText('method')}, 'GET')";
-        $path = "COALESCE({$this->jsonText('route_path')}, '/')";
 
-        $overview = $project->records()
-            ->ofType('request')
-            ->forPeriod($period, $from, $to)
-            ->select([
-                DB::raw('COUNT(*) as total'),
-                DB::raw("SUM(CASE WHEN {$statusCode} BETWEEN 100 AND 399 THEN 1 ELSE 0 END) as ok"),
-                DB::raw("SUM(CASE WHEN {$statusCode} BETWEEN 400 AND 499 THEN 1 ELSE 0 END) as client_error"),
-                DB::raw("SUM(CASE WHEN {$statusCode} >= 500 THEN 1 ELSE 0 END) as server_error"),
-                DB::raw("AVG({$duration}) as avg_duration"),
-                DB::raw("MAX({$duration}) as max_duration"),
-                DB::raw("MIN({$duration}) as min_duration"),
-            ])->first();
+        $overview = $this->rollupTotals($project, 'request', $period, $from, $to);
+
+        $requests = $this->groupList(
+            $project, 'request', $period, $from, $to,
+            sort: $sort,
+            direction: $direction,
+            sortMap: ['method' => 'label', 'path' => 'sublabel', 'p95_duration' => 'max_duration'],
+        )->through(function ($row) {
+            $row->method = $row->label;
+            $row->path = $row->sublabel;
+
+            return $row;
+        });
 
         return [
-            'requests' => $project->records()
-                ->ofType('request')
-                ->forPeriod($period, $from, $to)
-                ->select([
-                    DB::raw("{$method} as method"),
-                    DB::raw("{$path} as path"),
-                    'fingerprint as hash',
-                    DB::raw('COUNT(*) as total'),
-                    DB::raw("SUM(CASE WHEN {$statusCode} BETWEEN 100 AND 399 THEN 1 ELSE 0 END) as ok_count"),
-                    DB::raw("SUM(CASE WHEN {$statusCode} BETWEEN 400 AND 499 THEN 1 ELSE 0 END) as client_error_count"),
-                    DB::raw("SUM(CASE WHEN {$statusCode} >= 500 THEN 1 ELSE 0 END) as server_error_count"),
-                    DB::raw("AVG({$duration}) as avg_duration"),
-                    DB::raw("MAX({$duration}) as p95_duration"),
-                ])
-                ->groupBy('method', 'path', 'fingerprint')
-                ->orderBy($sort, $direction)
-                ->paginate(20)->withQueryString(),
+            'requests' => $requests,
             'timeSeries' => $this->getDetailedTimeSeries($project, 'request', $period, $from, $to),
             'overview' => [
-                'ok' => (int) ($overview->ok ?? 0),
-                'client_error' => (int) ($overview->client_error ?? 0),
-                'server_error' => (int) ($overview->server_error ?? 0),
-                'avg_duration' => round($overview->avg_duration ?? 0, 2),
-                'max_duration' => round($overview->max_duration ?? 0, 2),
-                'min_duration' => round($overview->min_duration ?? 0, 2),
+                'ok' => (int) $overview->ok,
+                'client_error' => (int) $overview->client_error,
+                'server_error' => (int) $overview->server_error,
+                'avg_duration' => round($this->avgDuration($overview), 2),
+                'max_duration' => round((float) ($overview->max_duration ?? 0), 2),
+                'min_duration' => round((float) ($overview->min_duration ?? 0), 2),
             ],
             'sort' => $sort,
             'direction' => $direction,
@@ -98,94 +92,43 @@ class RecordService
      */
     public function getDashboardStats(Project $project, ?string $period = null, ?string $from = null, ?string $to = null): array
     {
-        $records = $project->records()->forPeriod($period, $from, $to);
-        $statusCode = $this->jsonNumeric('status_code');
-        $duration = $this->jsonNumeric('duration');
-        $status = $this->jsonText('status');
-        $user = $this->jsonValue('user');
-        $userDistinct = $this->jsonDistinct('user');
-        $userId = "COALESCE({$this->jsonText('user.id')}, {$this->jsonText('user')}, 'Anonymous')";
-        $userIdentifier = "COALESCE({$this->jsonText('user.name')}, {$this->jsonText('user_name')}, {$this->jsonText('user')}, 'Anonymous')";
-        $userEmail = "COALESCE({$this->jsonText('user.email')}, {$this->jsonText('user_email')}, '')";
+        $requestStats = $this->rollupTotals($project, 'request', $period, $from, $to);
+        $exceptionStats = $this->rollupTotals($project, 'exception', $period, $from, $to);
+        $jobStats = $this->rollupTotals($project, ['job-attempt', 'queued-job'], $period, $from, $to);
 
-        $requestStats = (clone $records)->ofType('request')
-            ->select([
-                DB::raw('COUNT(*) as total'),
-                DB::raw("SUM(CASE WHEN {$statusCode} BETWEEN 100 AND 399 THEN 1 ELSE 0 END) as ok"),
-                DB::raw("SUM(CASE WHEN {$statusCode} BETWEEN 400 AND 499 THEN 1 ELSE 0 END) as client_error"),
-                DB::raw("SUM(CASE WHEN {$statusCode} >= 500 THEN 1 ELSE 0 END) as server_error"),
-                DB::raw("AVG({$duration}) as avg_duration"),
-                DB::raw("MAX({$duration}) as max_duration"),
-                DB::raw("MIN({$duration}) as min_duration"),
-            ])->first();
-
-        $jobStats = (clone $records)->whereIn('type', ['job-attempt', 'queued-job'])
-            ->select([
-                DB::raw('COUNT(*) as total'),
-                DB::raw("SUM(CASE WHEN {$status} = 'processed' THEN 1 ELSE 0 END) as processed"),
-                DB::raw("SUM(CASE WHEN {$status} = 'failed' THEN 1 ELSE 0 END) as failed"),
-                DB::raw("SUM(CASE WHEN {$status} = 'released' THEN 1 ELSE 0 END) as released"),
-                DB::raw("AVG({$duration}) as avg_duration"),
-                DB::raw("MAX({$duration}) as p95_duration"),
-            ])->first();
-
-        $impactedUsers = (clone $records)->ofType('exception')
-            ->whereRaw("{$user} IS NOT NULL")
-            ->select([
-                DB::raw("{$userId} as user_id"),
-                DB::raw("{$userIdentifier} as user_identifier"),
-                DB::raw("{$userEmail} as user_email"),
-                DB::raw('COUNT(*) as error_count'),
-                DB::raw('MAX(created_at) as last_seen'),
-            ])
-            ->groupBy('user_id', 'user_identifier', 'user_email')
-            ->orderBy('error_count', 'desc')
-            ->limit(5)
-            ->get();
-
-        $activeUsers = (clone $records)->ofType('request')
-            ->whereRaw("{$user} IS NOT NULL")
-            ->select([
-                DB::raw("{$userId} as user_id"),
-                DB::raw("{$userIdentifier} as user_identifier"),
-                DB::raw("{$userEmail} as user_email"),
-                DB::raw('COUNT(*) as request_count'),
-            ])
-            ->groupBy('user_id', 'user_identifier', 'user_email')
-            ->orderBy('request_count', 'desc')
-            ->limit(5)
-            ->get();
+        $impactedUsers = $this->topUsers($project, 'exception', 'error_count', $period, $from, $to);
+        $activeUsers = $this->topUsers($project, 'request', 'request_count', $period, $from, $to);
 
         $this->enrichUserRows($project, $impactedUsers);
         $this->enrichUserRows($project, $activeUsers);
 
         return [
-            'total_requests' => $requestStats->total ?? 0,
+            'total_requests' => (int) $requestStats->total,
             'request_breakdown' => [
-                'ok' => (int) ($requestStats->ok ?? 0),
-                'client_error' => (int) ($requestStats->client_error ?? 0),
-                'server_error' => (int) ($requestStats->server_error ?? 0),
+                'ok' => (int) $requestStats->ok,
+                'client_error' => (int) $requestStats->client_error,
+                'server_error' => (int) $requestStats->server_error,
             ],
             'duration_stats' => [
-                'avg' => round($requestStats->avg_duration ?? 0, 2),
-                'max' => round($requestStats->max_duration ?? 0, 2),
-                'min' => round($requestStats->min_duration ?? 0, 2),
+                'avg' => round($this->avgDuration($requestStats), 2),
+                'max' => round((float) ($requestStats->max_duration ?? 0), 2),
+                'min' => round((float) ($requestStats->min_duration ?? 0), 2),
             ],
-            'total_exceptions' => $project->records()->ofType('exception')->forPeriod($period, $from, $to)->count(),
+            'total_exceptions' => (int) $exceptionStats->total,
             'recent_issues' => $project->issues()->where('status', 'open')->latest('last_seen_at')->limit(5)->get(),
             'timeSeries' => $this->getDetailedTimeSeries($project, 'request', $period, $from, $to),
             'job_stats' => [
-                'total' => $jobStats->total ?? 0,
-                'processed' => (int) ($jobStats->processed ?? 0),
-                'failed' => (int) ($jobStats->failed ?? 0),
-                'released' => (int) ($jobStats->released ?? 0),
-                'avg_duration' => round(($jobStats->avg_duration ?? 0) / 1000, 2),
-                'p95_duration' => round(($jobStats->p95_duration ?? 0) / 1000, 2),
+                'total' => (int) $jobStats->total,
+                'processed' => (int) $jobStats->ok,
+                'failed' => (int) $jobStats->server_error,
+                'released' => (int) $jobStats->neutral,
+                'avg_duration' => round($this->avgDuration($jobStats) / 1000, 2),
+                'p95_duration' => round($this->p95Duration($jobStats) / 1000, 2),
             ],
             'impacted_users' => $impactedUsers,
             'active_users' => $activeUsers,
-            'auth_users_count' => (clone $records)->ofType('request')->whereRaw("{$user} IS NOT NULL")->distinct(DB::raw($userDistinct))->count(),
-            'guest_users_count' => (clone $records)->ofType('request')->whereRaw("{$user} IS NULL")->count(),
+            'auth_users_count' => $this->distinctUsers($project, 'request', $period, $from, $to),
+            'guest_users_count' => (int) $requestStats->total - (int) $requestStats->authed,
             'period' => $period,
             'uptime_status' => [
                 'current' => $project->last_uptime_status ?? 'unknown',
@@ -200,46 +143,39 @@ class RecordService
      */
     public function getUserStats(Project $project, ?string $period = null, ?string $from = null, ?string $to = null): array
     {
-        $records = $project->records()->forPeriod($period, $from, $to);
         $user = $this->jsonValue('user');
-        $userDistinct = $this->jsonDistinct('user');
         $statusCode = $this->jsonNumeric('status_code');
         $userHash = "MD5(COALESCE({$this->jsonText('user')}, 'Anonymous'))";
 
-        $authCount = (clone $records)->ofType('request')->whereRaw("{$user} IS NOT NULL")->distinct(DB::raw($userDistinct))->count();
-        $guestCount = (clone $records)->ofType('request')->whereRaw("{$user} IS NULL")->count();
-        $totalAuthRequests = (clone $records)->ofType('request')->whereRaw("{$user} IS NOT NULL")->count();
+        $requestTotals = $this->rollupTotals($project, 'request', $period, $from, $to);
+        $authCount = $this->distinctUsers($project, 'request', $period, $from, $to);
+        $totalAuthRequests = (int) $requestTotals->authed;
+        $guestCount = (int) $requestTotals->total - $totalAuthRequests;
+
+        $userKey = $this->col('user_key');
+        $isRequest = $this->col('type')." = 'request'";
+        $isException = $this->col('type')." = 'exception'";
+
+        $users = RecordUserBucket::query()
+            ->where('project_id', $project->id)
+            ->forPeriod($period, $from, $to)
+            ->select([
+                DB::raw("{$userKey} as user_id"),
+                DB::raw("{$userKey} as user_name"),
+                DB::raw("'' as user_email"),
+                DB::raw("MD5({$userKey}) as hash"),
+                DB::raw("SUM(CASE WHEN {$isRequest} THEN ".$this->col('count').' ELSE 0 END) as total_requests'),
+                DB::raw("SUM(CASE WHEN {$isRequest} THEN ".$this->col('error_count').' ELSE 0 END) as error_count'),
+                DB::raw("SUM(CASE WHEN {$isException} THEN ".$this->col('count').' ELSE 0 END) as exception_count'),
+                DB::raw('MAX('.$this->col('last_seen_at').') as last_seen'),
+            ])
+            ->groupBy('user_key')
+            ->orderBy('last_seen', 'desc')
+            ->paginate(20)
+            ->withQueryString();
 
         return [
-            'users' => $this->enrichUserPaginator($project, $project->records()
-                ->whereRaw("{$user} IS NOT NULL")
-                ->forPeriod($period, $from, $to)
-                ->select([
-                    DB::raw("COALESCE(
-                        {$this->jsonText('user.name')},
-                        {$this->jsonText('user_name')},
-                        {$this->jsonText('user')},
-                        'Anonymous'
-                    ) as user_name"),
-                    DB::raw("COALESCE(
-                        {$this->jsonText('user.email')},
-                        {$this->jsonText('user_email')},
-                        ''
-                    ) as user_email"),
-                    DB::raw("COALESCE(
-                        {$this->jsonText('user.id')},
-                        {$this->jsonText('user')},
-                        'Anonymous'
-                    ) as user_id"),
-                    DB::raw("{$userHash} as hash"),
-                    DB::raw('COUNT(*) as total_requests'),
-                    DB::raw('MAX(created_at) as last_seen'),
-                    DB::raw("SUM(CASE WHEN {$statusCode} >= 400 THEN 1 ELSE 0 END) as error_count"),
-                    DB::raw("SUM(CASE WHEN type = 'exception' THEN 1 ELSE 0 END) as exception_count"),
-                ])
-                ->groupBy('user_name', 'user_email', 'user_id', 'hash')
-                ->orderBy('last_seen', 'desc')
-                ->paginate(20)->withQueryString()),
+            'users' => $this->enrichUserPaginator($project, $users),
             'timeSeries' => $this->getDetailedTimeSeries($project, 'request', $period, $from, $to),
             'overview' => [
                 'auth_users' => $authCount,
@@ -255,51 +191,27 @@ class RecordService
     public function getJobStats(Project $project, ?string $period = null, ?string $from = null, ?string $to = null): array
     {
         $types = ['job-attempt', 'queued-job'];
-        $status = $this->jsonText('status');
-        $duration = $this->jsonNumeric('duration');
 
-        $overview = $project->records()
-            ->whereIn('type', $types)
-            ->forPeriod($period, $from, $to)
-            ->select([
-                DB::raw('COUNT(*) as total'),
-                DB::raw("SUM(CASE WHEN {$status} = 'processed' THEN 1 ELSE 0 END) as processed"),
-                DB::raw("SUM(CASE WHEN {$status} = 'failed' THEN 1 ELSE 0 END) as failed"),
-                DB::raw("AVG({$duration}) as avg_duration"),
-                DB::raw("MAX({$duration}) as max_duration"),
-            ])->first();
+        $overview = $this->rollupTotals($project, $types, $period, $from, $to);
+
+        $jobs = $this->groupList($project, $types, $period, $from, $to)
+            ->through(function ($row) {
+                $row->job_class = $row->label ?? 'Unknown Job';
+                $row->processed_count = (int) $row->ok_count;
+                $row->failed_count = (int) $row->server_error_count;
+
+                return $row;
+            });
 
         return [
-            'jobs' => $project->records()
-                ->whereIn('type', $types)
-                ->forPeriod($period, $from, $to)
-                ->select([
-                    DB::raw("COALESCE(
-                        {$this->jsonText('name')},
-                        {$this->jsonText('job')},
-                        {$this->jsonText('job_class')},
-                        {$this->jsonText('payload.name')},
-                        {$this->jsonText('payload.displayName')},
-                        {$this->jsonText('data.commandName')},
-                        'Unknown Job'
-                    ) as job_class"),
-                    'fingerprint as hash',
-                    DB::raw('COUNT(*) as total'),
-                    DB::raw("SUM(CASE WHEN {$status} = 'processed' THEN 1 ELSE 0 END) as processed_count"),
-                    DB::raw("SUM(CASE WHEN {$status} = 'failed' THEN 1 ELSE 0 END) as failed_count"),
-                    DB::raw("AVG({$duration}) as avg_duration"),
-                    DB::raw("MAX({$duration}) as p95_duration"),
-                ])
-                ->groupBy('job_class', 'fingerprint')
-                ->orderBy('total', 'desc')
-                ->paginate(20)->withQueryString(),
+            'jobs' => $jobs,
             'timeSeries' => $this->getDetailedTimeSeries($project, 'job-attempt', $period, $from, $to),
             'overview' => [
-                'total' => (int) ($overview->total ?? 0),
-                'processed' => (int) ($overview->processed ?? 0),
-                'failed' => (int) ($overview->failed ?? 0),
-                'avg_duration' => round($overview->avg_duration ?? 0, 2),
-                'max_duration' => round($overview->max_duration ?? 0, 2),
+                'total' => (int) $overview->total,
+                'processed' => (int) $overview->ok,
+                'failed' => (int) $overview->server_error,
+                'avg_duration' => round($this->avgDuration($overview), 2),
+                'max_duration' => round((float) ($overview->max_duration ?? 0), 2),
             ],
         ];
     }
@@ -309,36 +221,38 @@ class RecordService
      */
     public function getExceptionStats(Project $project, ?string $period = null, ?string $from = null, ?string $to = null): array
     {
-        $user = $this->jsonValue('user');
         $userDistinct = $this->jsonDistinct('user');
 
-        $overview = $project->records()
-            ->ofType('exception')
+        $overview = $this->rollupTotals($project, 'exception', $period, $from, $to);
+
+        $uniqueTypes = $this->distinctGroups($project, 'exception', $period, $from, $to);
+
+        $exceptions = $this->groupList($project, 'exception', $period, $from, $to, sort: 'last_seen');
+
+        $userCounts = RecordGroupUserBucket::query()
+            ->where('project_id', $project->id)
+            ->where('type', 'exception')
+            ->whereIn('group_key', collect($exceptions->items())->pluck('hash')->all())
             ->forPeriod($period, $from, $to)
-            ->select([
-                DB::raw('COUNT(*) as total'),
-                DB::raw('COUNT(DISTINCT fingerprint) as unique_types'),
-            ])->first();
+            ->select('group_key', DB::raw('COUNT(DISTINCT '.$this->col('user_key').') as users'))
+            ->groupBy('group_key')
+            ->pluck('users', 'group_key');
+
+        $exceptions->through(function ($row) use ($userCounts) {
+            $row->class = $row->label;
+            $row->message = $row->sublabel;
+            $row->total_count = (int) $row->total;
+            $row->user_count = (int) ($userCounts[$row->hash] ?? 0);
+
+            return $row;
+        });
 
         return [
-            'exceptions' => $project->records()
-                ->ofType('exception')
-                ->forPeriod($period, $from, $to)
-                ->select([
-                    'fingerprint as hash',
-                    DB::raw("{$this->jsonText('class')} as class"),
-                    DB::raw("{$this->jsonText('message')} as message"),
-                    DB::raw('COUNT(*) as total_count'),
-                    DB::raw("COUNT(DISTINCT {$userDistinct}) as user_count"),
-                    DB::raw('MAX(created_at) as last_seen'),
-                ])
-                ->groupBy('class', 'message', 'fingerprint')
-                ->orderBy('last_seen', 'desc')
-                ->paginate(20)->withQueryString(),
+            'exceptions' => $exceptions,
             'timeSeries' => $this->getDetailedTimeSeries($project, 'exception', $period, $from, $to),
             'overview' => [
-                'total' => (int) ($overview->total ?? 0),
-                'unique' => (int) ($overview->unique_types ?? 0),
+                'total' => (int) $overview->total,
+                'unique' => $uniqueTypes,
             ],
         ];
     }
@@ -351,43 +265,25 @@ class RecordService
         $exitCode = $this->jsonNumeric('exit_code');
         $duration = $this->jsonNumeric('duration');
 
-        $overview = $project->records()
-            ->ofType('command')
-            ->forPeriod($period, $from, $to)
-            ->select([
-                DB::raw('COUNT(*) as total'),
-                DB::raw("SUM(CASE WHEN {$exitCode} = 0 THEN 1 ELSE 0 END) as success"),
-                DB::raw("SUM(CASE WHEN {$exitCode} != 0 THEN 1 ELSE 0 END) as failed"),
-                DB::raw("AVG({$duration}) as avg_duration"),
-            ])->first();
+        $overview = $this->rollupTotals($project, 'command', $period, $from, $to);
+
+        $commands = $this->groupList($project, 'command', $period, $from, $to)
+            ->through(function ($row) {
+                $row->command_name = $row->label ?? 'Unknown Command';
+                $row->success_count = (int) $row->ok_count;
+                $row->failed_count = (int) $row->server_error_count;
+
+                return $row;
+            });
 
         return [
-            'commands' => $project->records()
-                ->ofType('command')
-                ->forPeriod($period, $from, $to)
-                ->select([
-                    DB::raw("COALESCE(
-                        {$this->jsonText('command')},
-                        {$this->jsonText('name')},
-                        {$this->jsonText('payload.command')},
-                        {$this->jsonText('data.command')},
-                        'Unknown Command'
-                    ) as command_name"),
-                    'fingerprint as hash',
-                    DB::raw('COUNT(*) as total'),
-                    DB::raw("SUM(CASE WHEN {$exitCode} = 0 THEN 1 ELSE 0 END) as success_count"),
-                    DB::raw("SUM(CASE WHEN {$exitCode} != 0 THEN 1 ELSE 0 END) as failed_count"),
-                    DB::raw("AVG({$duration}) as avg_duration"),
-                    DB::raw("MAX({$duration}) as p95_duration"),
-                ])
-                ->groupBy('command_name', 'fingerprint')
-                ->paginate(20)->withQueryString(),
+            'commands' => $commands,
             'timeSeries' => $this->getDetailedTimeSeries($project, 'command', $period, $from, $to),
             'overview' => [
-                'total' => (int) ($overview->total ?? 0),
-                'success' => (int) ($overview->success ?? 0),
-                'failed' => (int) ($overview->failed ?? 0),
-                'avg_duration' => round($overview->avg_duration ?? 0, 2),
+                'total' => (int) $overview->total,
+                'success' => (int) $overview->ok,
+                'failed' => (int) $overview->server_error,
+                'avg_duration' => round($this->avgDuration($overview), 2),
             ],
         ];
     }
@@ -402,63 +298,38 @@ class RecordService
         $duration = $this->jsonNumeric('duration');
         $status = $this->jsonText('status');
 
-        $overview = $project->records()
-            ->ofType('scheduled-task')
-            ->forPeriod($period, $from, $to)
-            ->select([
-                DB::raw('COUNT(*) as total'),
-                DB::raw("SUM(CASE WHEN {$exitCode} = 0 THEN 1 ELSE 0 END) as success"),
-                DB::raw("SUM(CASE WHEN {$exitCode} != 0 THEN 1 ELSE 0 END) as failed"),
-                DB::raw("AVG({$duration}) as avg_duration"),
-            ])->first();
+        $overview = $this->rollupTotals($project, 'scheduled-task', $period, $from, $to);
+
+        $tasks = $this->groupList($project, 'scheduled-task', $period, $from, $to)
+            ->through(function ($task) {
+                $task->command = $task->label ?? 'Unknown Task';
+                $task->schedule = $task->sublabel;
+                $task->processed_count = (int) $task->ok_count;
+                $task->failed_count = (int) $task->server_error_count;
+                $task->skipped_count = (int) $task->neutral_count;
+
+                try {
+                    if ($task->schedule) {
+                        $cron = new CronExpression($task->schedule);
+                        $task->next_run = $cron->getNextRunDate()->format('Y-m-d H:i:s');
+                    } else {
+                        $task->next_run = 'N/A';
+                    }
+                } catch (\Exception $e) {
+                    $task->next_run = 'Invalid Schedule';
+                }
+
+                return $task;
+            });
 
         return [
-            'tasks' => $project->records()
-                ->ofType('scheduled-task')
-                ->forPeriod($period, $from, $to)
-                ->select([
-                    DB::raw("COALESCE(
-                        {$this->jsonText('command')},
-                        {$this->jsonText('name')},
-                        {$this->jsonText('payload.command')},
-                        'Unknown Task'
-                    ) as command"),
-                    DB::raw("COALESCE(
-                        {$this->jsonText('cron')},
-                        {$this->jsonText('expression')},
-                        {$this->jsonText('schedule')}
-                    ) as schedule"),
-                    'fingerprint as hash',
-                    DB::raw('COUNT(*) as total'),
-                    DB::raw("SUM(CASE WHEN {$exitCode} = 0 THEN 1 ELSE 0 END) as processed_count"),
-                    DB::raw("SUM(CASE WHEN {$exitCode} != 0 AND {$exitCodeValue} IS NOT NULL THEN 1 ELSE 0 END) as failed_count"),
-                    DB::raw("SUM(CASE WHEN {$status} = 'skipped' THEN 1 ELSE 0 END) as skipped_count"),
-                    DB::raw("AVG({$duration}) as avg_duration"),
-                    DB::raw("MAX({$duration}) as p95_duration"),
-                ])
-                ->groupBy('command', 'schedule', 'fingerprint')
-                ->orderBy('total', 'desc')
-                ->paginate(20)
-                ->through(function ($task) {
-                    try {
-                        if ($task->schedule) {
-                            $cron = new CronExpression($task->schedule);
-                            $task->next_run = $cron->getNextRunDate()->format('Y-m-d H:i:s');
-                        } else {
-                            $task->next_run = 'N/A';
-                        }
-                    } catch (\Exception $e) {
-                        $task->next_run = 'Invalid Schedule';
-                    }
-
-                    return $task;
-                }),
+            'tasks' => $tasks,
             'timeSeries' => $this->getDetailedTimeSeries($project, 'scheduled-task', $period, $from, $to),
             'overview' => [
-                'total' => (int) ($overview->total ?? 0),
-                'success' => (int) ($overview->success ?? 0),
-                'failed' => (int) ($overview->failed ?? 0),
-                'avg_duration' => round($overview->avg_duration ?? 0, 2),
+                'total' => (int) $overview->total,
+                'success' => (int) $overview->ok,
+                'failed' => (int) $overview->server_error,
+                'avg_duration' => round($this->avgDuration($overview), 2),
             ],
         ];
     }
@@ -470,34 +341,24 @@ class RecordService
     {
         $duration = $this->jsonNumeric('duration');
 
-        $overview = $project->records()
-            ->ofType('query')
-            ->forPeriod($period, $from, $to)
-            ->select([
-                DB::raw('COUNT(*) as total'),
-                DB::raw("AVG({$duration}) as avg_duration"),
-            ])->first();
+        $overview = $this->rollupTotals($project, 'query', $period, $from, $to);
+
+        $queries = $this->groupList($project, 'query', $period, $from, $to)
+            ->through(function ($row) {
+                $row->sql_query = $row->sublabel;
+                $row->db_connection = $row->label ?? 'mysql';
+                $row->total_calls = (int) $row->total;
+                $row->total_duration = (float) $row->sum_duration;
+
+                return $row;
+            });
 
         return [
-            'queries' => $project->records()
-                ->ofType('query')
-                ->forPeriod($period, $from, $to)
-                ->select([
-                    'fingerprint as hash',
-                    DB::raw("{$this->jsonText('sql')} as sql_query"),
-                    DB::raw("COALESCE({$this->jsonText('connection')}, 'mysql') as db_connection"),
-                    DB::raw('COUNT(*) as total_calls'),
-                    DB::raw("AVG({$duration}) as avg_duration"),
-                    DB::raw("MAX({$duration}) as p95_duration"),
-                    DB::raw("SUM({$duration}) as total_duration"),
-                ])
-                ->groupBy('sql_query', 'hash', 'db_connection')
-                ->orderBy('total_calls', 'desc')
-                ->paginate(20)->withQueryString(),
+            'queries' => $queries,
             'timeSeries' => $this->getDetailedTimeSeries($project, 'query', $period, $from, $to),
             'overview' => [
-                'total' => (int) ($overview->total ?? 0),
-                'avg_duration' => round($overview->avg_duration ?? 0, 2),
+                'total' => (int) $overview->total,
+                'avg_duration' => round($this->avgDuration($overview), 2),
             ],
         ];
     }
@@ -512,39 +373,23 @@ class RecordService
         $resolvedStatus = "COALESCE({$statusCode}, {$status})";
         $duration = $this->jsonNumeric('duration');
 
-        $overview = $project->records()
-            ->ofType('outgoing-request')
-            ->forPeriod($period, $from, $to)
-            ->select([
-                DB::raw('COUNT(*) as total'),
-                DB::raw("SUM(CASE WHEN {$resolvedStatus} BETWEEN 100 AND 399 THEN 1 ELSE 0 END) as ok"),
-                DB::raw("SUM(CASE WHEN {$resolvedStatus} >= 400 THEN 1 ELSE 0 END) as failed"),
-                DB::raw("AVG({$duration}) as avg_duration"),
-            ])->first();
+        $overview = $this->rollupTotals($project, 'outgoing-request', $period, $from, $to);
+
+        $hosts = $this->groupList($project, 'outgoing-request', $period, $from, $to)
+            ->through(function ($row) {
+                $row->host = $row->label;
+
+                return $row;
+            });
 
         return [
-            'hosts' => $project->records()
-                ->ofType('outgoing-request')
-                ->forPeriod($period, $from, $to)
-                ->select([
-                    DB::raw("{$this->jsonText('host')} as host"),
-                    'fingerprint as hash',
-                    DB::raw('COUNT(*) as total'),
-                    DB::raw("SUM(CASE WHEN {$resolvedStatus} BETWEEN 100 AND 399 THEN 1 ELSE 0 END) as ok_count"),
-                    DB::raw("SUM(CASE WHEN {$resolvedStatus} BETWEEN 400 AND 499 THEN 1 ELSE 0 END) as client_error_count"),
-                    DB::raw("SUM(CASE WHEN {$resolvedStatus} >= 500 THEN 1 ELSE 0 END) as server_error_count"),
-                    DB::raw("AVG({$duration}) as avg_duration"),
-                    DB::raw("MAX({$duration}) as p95_duration"),
-                ])
-                ->groupBy('host', 'fingerprint')
-                ->orderBy('total', 'desc')
-                ->paginate(20)->withQueryString(),
+            'hosts' => $hosts,
             'timeSeries' => $this->getDetailedTimeSeries($project, 'outgoing-request', $period, $from, $to),
             'overview' => [
-                'total' => (int) ($overview->total ?? 0),
-                'ok' => (int) ($overview->ok ?? 0),
-                'failed' => (int) ($overview->failed ?? 0),
-                'avg_duration' => round($overview->avg_duration ?? 0, 2),
+                'total' => (int) $overview->total,
+                'ok' => (int) $overview->ok,
+                'failed' => (int) $overview->client_error + (int) $overview->server_error,
+                'avg_duration' => round($this->avgDuration($overview), 2),
             ],
         ];
     }
@@ -556,37 +401,24 @@ class RecordService
     {
         $cacheType = $this->jsonText('type');
 
-        $overview = $project->records()
-            ->ofType('cache-event')
-            ->forPeriod($period, $from, $to)
-            ->select([
-                DB::raw('COUNT(*) as total'),
-                DB::raw("SUM(CASE WHEN {$cacheType} = 'hit' THEN 1 ELSE 0 END) as hits"),
-                DB::raw("SUM(CASE WHEN {$cacheType} = 'miss' THEN 1 ELSE 0 END) as misses"),
-            ])->first();
+        $overview = $this->rollupTotals($project, 'cache-event', $period, $from, $to);
+
+        $keys = $this->groupList($project, 'cache-event', $period, $from, $to)
+            ->through(function ($row) {
+                $row->cache_key = $row->label;
+                $row->hit_rate = $row->total > 0 ? round(((int) $row->hits / (int) $row->total) * 100, 2) : 0;
+
+                return $row;
+            });
 
         return [
-            'keys' => $project->records()
-                ->ofType('cache-event')
-                ->forPeriod($period, $from, $to)
-                ->select([
-                    DB::raw("{$this->jsonText('key')} as cache_key"),
-                    DB::raw('COUNT(*) as total'),
-                    DB::raw("SUM(CASE WHEN {$cacheType} = 'hit' THEN 1 ELSE 0 END) as hits"),
-                    DB::raw("SUM(CASE WHEN {$cacheType} = 'miss' THEN 1 ELSE 0 END) as misses"),
-                    DB::raw("SUM(CASE WHEN {$cacheType} = 'write' THEN 1 ELSE 0 END) as writes"),
-                    DB::raw("SUM(CASE WHEN {$cacheType} = 'delete' THEN 1 ELSE 0 END) as deletes"),
-                    DB::raw("(SUM(CASE WHEN {$cacheType} = 'hit' THEN 1 ELSE 0 END) * 100 / NULLIF(COUNT(*), 0)) as hit_rate"),
-                ])
-                ->groupBy('cache_key')
-                ->orderBy('total', 'desc')
-                ->paginate(20)->withQueryString(),
+            'keys' => $keys,
             'timeSeries' => $this->getDetailedTimeSeries($project, 'cache-event', $period, $from, $to),
             'overview' => [
-                'total' => (int) ($overview->total ?? 0),
-                'hits' => (int) ($overview->hits ?? 0),
-                'misses' => (int) ($overview->misses ?? 0),
-                'hit_rate' => $overview->total > 0 ? round(($overview->hits / $overview->total) * 100, 2) : 0,
+                'total' => (int) $overview->total,
+                'hits' => (int) $overview->hits,
+                'misses' => (int) $overview->misses,
+                'hit_rate' => $overview->total > 0 ? round(((int) $overview->hits / (int) $overview->total) * 100, 2) : 0,
             ],
         ];
     }
@@ -599,32 +431,25 @@ class RecordService
         $channel = $this->jsonDistinct('channel');
         $status = $this->jsonText('status');
 
-        $overview = $project->records()
-            ->ofType('notification')
-            ->forPeriod($period, $from, $to)
-            ->select([
-                DB::raw('COUNT(*) as total'),
-                DB::raw("COUNT(DISTINCT {$channel}) as channels_count"),
-            ])->first();
+        $overview = $this->rollupTotals($project, 'notification', $period, $from, $to);
+
+        $channelsCount = $this->distinctGroups($project, 'notification', $period, $from, $to, 'sublabel');
+
+        $notifications = $this->groupList($project, 'notification', $period, $from, $to)
+            ->through(function ($row) {
+                $row->notification_class = $row->label;
+                $row->channel = $row->sublabel;
+                $row->failed_count = (int) $row->server_error_count;
+                $row->sent_count = (int) $row->total - $row->failed_count;
+
+                return $row;
+            });
 
         return [
-            'notifications' => $project->records()
-                ->ofType('notification')
-                ->forPeriod($period, $from, $to)
-                ->select([
-                    'fingerprint as hash',
-                    DB::raw("{$this->jsonText('class')} as notification_class"),
-                    DB::raw("{$this->jsonText('channel')} as channel"),
-                    DB::raw('COUNT(*) as total'),
-                    DB::raw("SUM(CASE WHEN {$status} != 'failed' THEN 1 ELSE 0 END) as sent_count"),
-                    DB::raw("SUM(CASE WHEN {$status} = 'failed' THEN 1 ELSE 0 END) as failed_count"),
-                ])
-                ->groupBy('hash', 'notification_class', 'channel')
-                ->orderBy('total', 'desc')
-                ->paginate(20)->withQueryString(),
+            'notifications' => $notifications,
             'overview' => [
-                'total' => (int) ($overview->total ?? 0),
-                'channels' => (int) ($overview->channels_count ?? 0),
+                'total' => (int) $overview->total,
+                'channels' => $channelsCount,
             ],
         ];
     }
@@ -636,30 +461,23 @@ class RecordService
     {
         $mailer = $this->jsonText('mailer');
 
-        $overview = $project->records()
-            ->ofType('mail')
-            ->forPeriod($period, $from, $to)
-            ->select([
-                DB::raw('COUNT(*) as total'),
-                DB::raw('COUNT(DISTINCT fingerprint) as unique_mailables'),
-            ])->first();
+        $overview = $this->rollupTotals($project, 'mail', $period, $from, $to);
+
+        $uniqueMailables = $this->distinctGroups($project, 'mail', $period, $from, $to);
+
+        $mailables = $this->groupList($project, 'mail', $period, $from, $to)
+            ->through(function ($row) {
+                $row->mailable_class = $row->label;
+                $row->queued_count = (int) $row->ok_count;
+
+                return $row;
+            });
 
         return [
-            'mailables' => $project->records()
-                ->ofType('mail')
-                ->forPeriod($period, $from, $to)
-                ->select([
-                    'fingerprint as hash',
-                    DB::raw("{$this->jsonText('class')} as mailable_class"),
-                    DB::raw('COUNT(*) as total'),
-                    DB::raw("SUM(CASE WHEN {$mailer} = 'log' THEN 0 ELSE 1 END) as queued_count"),
-                ])
-                ->groupBy('hash', 'mailable_class')
-                ->orderBy('total', 'desc')
-                ->paginate(20)->withQueryString(),
+            'mailables' => $mailables,
             'overview' => [
-                'total' => (int) ($overview->total ?? 0),
-                'unique' => (int) ($overview->unique_mailables ?? 0),
+                'total' => (int) $overview->total,
+                'unique' => $uniqueMailables,
             ],
         ];
     }
@@ -674,14 +492,14 @@ class RecordService
             ->forPeriod($period, $from, $to)
             ->latest()
             ->paginate(50)
+            ->withQueryString()
             ->through(function ($record) {
                 if (isset($record->payload['payload']) && is_array($record->payload['payload'])) {
                     $record->payload = array_merge($record->payload, $record->payload['payload']);
                 }
 
                 return $record;
-            })
-            ->withQueryString();
+            });
     }
 
     /**
@@ -689,10 +507,10 @@ class RecordService
      */
     public function getUserHistory(Project $project, string $hash, ?string $period = null, ?string $from = null, ?string $to = null): array
     {
-        $userHash = "MD5(COALESCE({$this->jsonText('user')}, 'Anonymous'))";
+        $userKey = $this->resolveUserKeyFromHash($project, $hash);
 
         $records = $project->records()
-            ->whereRaw("{$userHash} = ?", [$hash])
+            ->where('user_key', $userKey)
             ->forPeriod($period, $from, $to)
             ->latest()
             ->paginate(50)
@@ -724,13 +542,25 @@ class RecordService
             'user_identifier' => $user_name, // legacy support
             'records' => $records,
             'stats' => $project->records()->forPeriod($period, $from, $to)
-                ->whereRaw("{$userHash} = ?", [$hash])
+                ->where('user_key', $userKey)
                 ->select([
                     DB::raw('COUNT(*) as total'),
                     DB::raw('MIN(created_at) as first_seen'),
                     DB::raw('MAX(created_at) as last_seen'),
                 ])->first(),
         ];
+    }
+
+    /**
+     * Searched over `record_user_buckets`, which holds one row per user per
+     * hour rather than one per record.
+     */
+    protected function resolveUserKeyFromHash(Project $project, string $hash): ?string
+    {
+        return RecordUserBucket::query()
+            ->where('project_id', $project->id)
+            ->whereRaw('MD5('.$this->col('user_key').') = ?', [$hash])
+            ->value('user_key');
     }
 
     /**
@@ -763,20 +593,14 @@ class RecordService
      */
     public function getLogRecords(Project $project, ?string $search = null, ?string $period = null, ?string $from = null, ?string $to = null): LengthAwarePaginator
     {
-        return $project->records()
-            ->ofType('log')
-            ->forPeriod($period, $from, $to)
-            ->when($search, fn ($q) => $q->where('payload', 'like', '%'.$search.'%'))
-            ->latest()
-            ->paginate(50)
+        return $this->paginateRawRecords($project, 'log', $search, $period, $from, $to, searchMessage: true)
             ->through(function ($record) {
                 if (isset($record->payload['payload']) && is_array($record->payload['payload'])) {
                     $record->payload = array_merge($record->payload, $record->payload['payload']);
                 }
 
                 return $record;
-            })
-            ->withQueryString();
+            });
     }
 
     /**
@@ -784,20 +608,65 @@ class RecordService
      */
     public function getPaginatedRecords(Project $project, string $type, ?string $search = null, ?string $period = null, ?string $from = null, ?string $to = null): LengthAwarePaginator
     {
-        $typeMap = [
+        return $this->paginateRawRecords($project, $this->resolveRecordType($type), $search, $period, $from, $to);
+    }
+
+    /**
+     * A page of raw records, counted by the rollups rather than by the database.
+     */
+    protected function paginateRawRecords(Project $project, string $type, ?string $search, ?string $period, ?string $from, ?string $to, bool $searchMessage = false): LengthAwarePaginator
+    {
+        $query = $project->records()
+            ->ofType($type)
+            ->forPeriod($period, $from, $to)
+            ->latest();
+
+        if ($search) {
+            if ($searchMessage) {
+                $this->applyMessageSearch($query, $search);
+            } else {
+                $query->where('payload', 'like', '%'.$search.'%');
+            }
+
+            return $query->paginate(50)->withQueryString();
+        }
+
+        return $this->paginateWithKnownTotal($query, $this->rollupCount($project, $type, $period, $from, $to));
+    }
+
+    /**
+     * Search the FULLTEXT-indexed `message` column.
+     *
+     * Uses the index on MySQL/MariaDB and PostgreSQL. FULLTEXT ignores tokens
+     * shorter than its minimum length, and SQLite has no such index, so those
+     * cases fall back to a LIKE over the same narrow column — still far cheaper
+     * than scanning the JSON payload.
+     *
+     * @param  Builder<Record>|HasMany<Record, Project>  $query
+     */
+    protected function applyMessageSearch($query, string $search): void
+    {
+        $term = trim($search);
+        $driver = DB::connection()->getDriverName();
+
+        if ($term !== '' && mb_strlen($term) >= 3 && in_array($driver, ['mysql', 'mariadb', 'pgsql'], true)) {
+            $query->whereFullText('message', $term);
+
+            return;
+        }
+
+        $query->where('message', 'like', '%'.$term.'%');
+    }
+
+    /**
+     * Map a route segment onto the record type the client emits.
+     */
+    protected function resolveRecordType(string $type): string
+    {
+        return [
             'job' => 'job-attempt',
             'cache' => 'cache-event',
-        ];
-
-        $actualType = $typeMap[$type] ?? $type;
-
-        return $project->records()
-            ->ofType($actualType)
-            ->forPeriod($period, $from, $to)
-            ->when($search, fn ($q) => $q->where('payload', 'like', '%'.$search.'%'))
-            ->latest()
-            ->paginate(50)
-            ->withQueryString();
+        ][$type] ?? $type;
     }
 
     /**
@@ -806,13 +675,21 @@ class RecordService
     public function getSecurityStats(Project $project, ?string $period = null, ?string $from = null, ?string $to = null): array
     {
         $records = $project->records()->ofType('request')->forPeriod($period, $from, $to);
-        $ip = $this->jsonDistinct('ip');
         $status = $this->jsonText('status');
 
-        $overview = (clone $records)->select([
-            DB::raw("COUNT(DISTINCT {$ip}) as unique_ips"),
-            DB::raw('COUNT(*) as total_requests'),
-        ])->first();
+        $uniqueIps = RecordIpBucket::query()
+            ->where('project_id', $project->id)
+            ->where('type', 'request')
+            ->forPeriod($period, $from, $to)
+            ->distinct()
+            ->count('ip');
+
+        $totalRequests = $this->rollupCount($project, 'request', $period, $from, $to);
+
+        $overview = (object) [
+            'unique_ips' => $uniqueIps,
+            'total_requests' => $totalRequests,
+        ];
 
         // Failed logins (last 24h or selected period)
         $failedLogins = $project->records()
@@ -866,53 +743,74 @@ class RecordService
     protected function getDetailedTimeSeries(Project $project, string $type, ?string $period = null, ?string $from = null, ?string $to = null): array
     {
         $period = $period ?: '1h';
-        $query = $project->records()
-            ->ofType($type)
-            ->forPeriod($period, $from, $to);
 
-        $timeBucket = $this->timeBucketSql($period);
-        $statusCode = $this->jsonNumeric('status_code');
-        $status = $this->jsonText('status');
-        $exitCode = $this->jsonNumeric('exit_code');
-        $exitCodeValue = $this->jsonValue('exit_code');
-        $cacheType = $this->jsonText('type');
-        $duration = $this->jsonNumeric('duration');
-        $user = $this->jsonDistinct('user');
+        $groupsByMinute = ! in_array($period, ['7d', '14d', '30d', 'custom'], true);
+        $bucket = $groupsByMinute ? $this->col('bucket') : $this->timeBucketSql($period, 'bucket');
 
-        $results = $query->select([
-            DB::raw("{$timeBucket} as minute"),
-            DB::raw('COUNT(*) as total'),
-            DB::raw("SUM(CASE
-                WHEN {$statusCode} BETWEEN 100 AND 399 THEN 1
-                WHEN {$status} = 'processed' THEN 1
-                WHEN {$exitCode} = 0 THEN 1
-                WHEN {$cacheType} = 'hit' THEN 1
-                ELSE 0
-            END) as ok"),
-            DB::raw("SUM(CASE
-                WHEN {$statusCode} BETWEEN 400 AND 499 THEN 1
-                ELSE 0
-            END) as client_error"),
-            DB::raw("SUM(CASE
-                WHEN {$statusCode} >= 500 THEN 1
-                WHEN {$status} = 'failed' THEN 1
-                WHEN type = 'exception' THEN 1
-                WHEN {$exitCode} != 0 AND {$exitCodeValue} IS NOT NULL THEN 1
-                WHEN {$cacheType} = 'miss' THEN 1
-                ELSE 0
-            END) as server_error"),
-            DB::raw("AVG({$duration}) as avg_duration"),
-            DB::raw("SUM(CASE WHEN {$cacheType} = 'hit' THEN 1 ELSE 0 END) as hits"),
-            DB::raw("SUM(CASE WHEN {$cacheType} = 'miss' THEN 1 ELSE 0 END) as misses"),
-            DB::raw("SUM(CASE WHEN {$cacheType} = 'write' THEN 1 ELSE 0 END) as writes"),
-            DB::raw("COUNT(DISTINCT {$user}) as active_users"),
-            DB::raw('COUNT(*) as total_requests'),
-        ])
+        $sum = fn (string $column, string $alias) => DB::raw('SUM('.$this->col($column).') as '.$alias);
+
+        $results = RecordRollup::query()
+            ->where('project_id', $project->id)
+            ->where('type', $type)
+            ->forPeriod($period, $from, $to)
+            ->select([
+                DB::raw("{$bucket} as minute"),
+                $sum('count', 'total'),
+                $sum('ok_count', 'ok'),
+                $sum('client_error_count', 'client_error'),
+                $sum('server_error_count', 'server_error'),
+                $sum('hits', 'hits'),
+                $sum('misses', 'misses'),
+                $sum('writes', 'writes'),
+                DB::raw('SUM('.$this->col('sum_duration').') / NULLIF(SUM('.$this->col('count_duration').'), 0) as avg_duration'),
+            ])
             ->groupBy('minute')
+            ->get();
+
+        $userBucket = $groupsByMinute ? $this->col('bucket') : $bucket;
+
+        $activeUsers = RecordUserBucket::query()
+            ->where('project_id', $project->id)
+            ->where('type', $type)
+            ->forPeriod($period, $from, $to)
+            ->select([
+                DB::raw("{$userBucket} as slot"),
+                DB::raw('COUNT(DISTINCT '.$this->col('user_key').') as active_users'),
+            ])
+            ->groupBy('slot')
             ->get()
-            ->keyBy('minute');
+            ->mapWithKeys(fn ($row) => [
+                $groupsByMinute ? Carbon::parse($row->slot)->format('Y-m-d H') : $row->slot => (int) $row->active_users,
+            ]);
+
+        $results = $results->mapWithKeys(function ($row) use ($activeUsers, $groupsByMinute) {
+            $key = $this->seriesKey($row->minute, $groupsByMinute);
+            $userSlot = $groupsByMinute ? Carbon::parse($row->minute)->format('Y-m-d H') : $row->minute;
+
+            return [$key => [
+                'minute' => $key,
+                'total' => (int) $row->total,
+                'ok' => (int) $row->ok,
+                'client_error' => (int) $row->client_error,
+                'server_error' => (int) $row->server_error,
+                'avg_duration' => round((float) $row->avg_duration, 2),
+                'hits' => (int) $row->hits,
+                'misses' => (int) $row->misses,
+                'writes' => (int) $row->writes,
+                'active_users' => $activeUsers[$userSlot] ?? 0,
+                'total_requests' => (int) $row->total,
+            ]];
+        });
 
         return $this->fillTimeSeriesGaps($results, $period, $from, $to);
+    }
+
+    /**
+     * The chart key a grouped row belongs to.
+     */
+    private function seriesKey(string $value, bool $groupedByMinute): string
+    {
+        return $groupedByMinute ? Carbon::parse($value)->format('H:i') : $value;
     }
 
     /**
@@ -1179,20 +1077,251 @@ class RecordService
         return 'CAST('.$this->jsonValue($path).' AS CHAR)';
     }
 
-    private function timeBucketSql(string $period): string
+    private function timeBucketSql(string $period, string $column = 'created_at'): string
     {
         if ($this->isPgsql()) {
             return match ($period) {
-                '7d', '14d', '30d' => "to_char(created_at, 'MM-DD')",
-                'custom' => "to_char(date_trunc('hour', created_at), 'YYYY-MM-DD HH24:00')",
-                default => "to_char(created_at, 'HH24:MI')",
+                '7d', '14d', '30d' => "to_char({$column}, 'MM-DD')",
+                'custom' => "to_char(date_trunc('hour', {$column}), 'YYYY-MM-DD HH24:00')",
+                default => "to_char({$column}, 'HH24:MI')",
             };
         }
 
         return match ($period) {
-            '7d', '14d', '30d' => "DATE_FORMAT(created_at, '%m-%d')",
-            'custom' => "DATE_FORMAT(created_at, '%Y-%m-%d %H:00')",
-            default => "DATE_FORMAT(created_at, '%H:%i')",
+            '7d', '14d', '30d' => "DATE_FORMAT({$column}, '%m-%d')",
+            'custom' => "DATE_FORMAT({$column}, '%Y-%m-%d %H:00')",
+            default => "DATE_FORMAT({$column}, '%H:%i')",
         };
+    }
+
+    /**
+     * Quote an identifier for the active driver.
+     */
+    private function col(string $name): string
+    {
+        return DB::connection()->getQueryGrammar()->wrap($name);
+    }
+
+    /**
+     * Paginate raw records without asking the database to count them.
+     *
+     * @param  Builder<Record>|HasMany<Record, Project>  $query
+     */
+    protected function paginateWithKnownTotal($query, int $total, int $perPage = 50): LengthAwarePaginator
+    {
+        $page = Paginator::resolveCurrentPage();
+
+        $items = $total === 0
+            ? collect()
+            : $query->forPage($page, $perPage)->get();
+
+        return new LengthAwarePaginator($items, $total, $perPage, $page, [
+            'path' => Paginator::resolveCurrentPath(),
+            'query' => request()->query(),
+        ]);
+    }
+
+    /**
+     * How many records of these types the rollups counted over the period.
+     *
+     * @param  string|list<string>  $types
+     */
+    protected function rollupCount(Project $project, string|array $types, ?string $period, ?string $from, ?string $to): int
+    {
+        return (int) RecordRollup::query()
+            ->where('project_id', $project->id)
+            ->whereIn('type', (array) $types)
+            ->forPeriod($period, $from, $to)
+            ->sum('count');
+    }
+
+    /**
+     * Distinct groups of a type over the period, straight off the group rollups.
+     */
+    protected function distinctGroups(Project $project, string $type, ?string $period, ?string $from, ?string $to, string $column = 'group_key'): int
+    {
+        return RecordGroupRollup::query()
+            ->where('project_id', $project->id)
+            ->where('type', $type)
+            ->forPeriod($period, $from, $to)
+            ->distinct()
+            ->count($column);
+    }
+
+    /**
+     * Sum the pre-aggregated counters for the given record types over a period.
+     *
+     * @param  string|list<string>  $types
+     */
+    protected function rollupTotals(Project $project, string|array $types, ?string $period = null, ?string $from = null, ?string $to = null): object
+    {
+        $sum = fn (string $column, string $alias) => DB::raw('COALESCE(SUM('.$this->col($column).'), 0) as '.$alias);
+
+        $columns = [
+            $sum('count', 'total'),
+            $sum('ok_count', 'ok'),
+            $sum('client_error_count', 'client_error'),
+            $sum('server_error_count', 'server_error'),
+            $sum('neutral_count', 'neutral'),
+            $sum('hits', 'hits'),
+            $sum('misses', 'misses'),
+            $sum('writes', 'writes'),
+            $sum('authed_count', 'authed'),
+            $sum('sum_duration', 'sum_duration'),
+            $sum('count_duration', 'count_duration'),
+            DB::raw('MAX('.$this->col('max_duration').') as max_duration'),
+            DB::raw('MIN('.$this->col('min_duration').') as min_duration'),
+        ];
+
+        foreach (RollupWriter::latencyColumns() as $column) {
+            $columns[] = $sum($column, $column);
+        }
+
+        return RecordRollup::query()
+            ->where('project_id', $project->id)
+            ->whereIn('type', (array) $types)
+            ->forPeriod($period, $from, $to)
+            ->select($columns)
+            ->first();
+    }
+
+    /**
+     * The mean duration. Averages are not additive, so they are recomputed from
+     */
+    protected function avgDuration(object $totals): float
+    {
+        $count = (int) ($totals->count_duration ?? 0);
+
+        return $count > 0 ? ((float) $totals->sum_duration) / $count : 0.0;
+    }
+
+    /**
+     * An approximate 95th percentile, read off the latency histogram.
+     */
+    protected function p95Duration(object $totals): float
+    {
+        $samples = (int) ($totals->count_duration ?? 0);
+
+        if ($samples === 0) {
+            return 0.0;
+        }
+
+        $target = 0.95 * $samples;
+        $cumulative = 0;
+
+        foreach (RollupWriter::LATENCY_BOUNDARIES as $boundary) {
+            $cumulative += (int) ($totals->{'lat_le_'.$boundary} ?? 0);
+
+            if ($cumulative >= $target) {
+                return (float) $boundary;
+            }
+        }
+
+        return (float) ($totals->max_duration ?? 0);
+    }
+
+    /**
+     * The grouped list behind a type's top-N page, read from the group rollups.
+     *
+     * @param  string|list<string>  $types
+     * @param  array<string, string>  $extraColumns  alias => SQL aggregate
+     * @param  array<string, string>  $sortMap  request sort key => SQL alias
+     */
+    protected function groupList(
+        Project $project,
+        string|array $types,
+        ?string $period,
+        ?string $from,
+        ?string $to,
+        array $extraColumns = [],
+        string $sort = 'total',
+        string $direction = 'desc',
+        array $sortMap = [],
+    ): LengthAwarePaginator {
+        $sum = fn (string $column, string $alias) => DB::raw('SUM('.$this->col($column).') as '.$alias);
+
+        $columns = [
+            DB::raw($this->col('group_key').' as hash'),
+            DB::raw('MAX('.$this->col('label').') as label'),
+            DB::raw('MAX('.$this->col('sublabel').') as sublabel'),
+            $sum('count', 'total'),
+            $sum('ok_count', 'ok_count'),
+            $sum('client_error_count', 'client_error_count'),
+            $sum('server_error_count', 'server_error_count'),
+            $sum('neutral_count', 'neutral_count'),
+            $sum('hits', 'hits'),
+            $sum('misses', 'misses'),
+            $sum('writes', 'writes'),
+            $sum('deletes', 'deletes'),
+            $sum('sum_duration', 'sum_duration'),
+            $sum('count_duration', 'count_duration'),
+            DB::raw('MAX('.$this->col('max_duration').') as max_duration'),
+            DB::raw('MIN('.$this->col('min_duration').') as min_duration'),
+            DB::raw('MAX('.$this->col('last_seen_at').') as last_seen'),
+            DB::raw('SUM('.$this->col('sum_duration').') / NULLIF(SUM('.$this->col('count_duration').'), 0) as avg_duration'),
+        ];
+
+        foreach (RollupWriter::latencyColumns() as $column) {
+            $columns[] = $sum($column, $column);
+        }
+
+        foreach ($extraColumns as $alias => $expression) {
+            $columns[] = DB::raw($expression.' as '.$alias);
+        }
+
+        $orderBy = $sortMap[$sort] ?? $sort;
+
+        return RecordGroupRollup::query()
+            ->where('project_id', $project->id)
+            ->whereIn('type', (array) $types)
+            ->forPeriod($period, $from, $to)
+            ->select($columns)
+            ->groupBy('group_key')
+            ->orderBy($orderBy, $direction)
+            ->paginate(20)
+            ->withQueryString()
+            ->through(function ($row) {
+                $row->p95_duration = $this->p95Duration($row);
+                $row->avg_duration = round((float) $row->avg_duration, 2);
+
+                return $row;
+            });
+    }
+
+    /**
+     * The five users producing the most records of a type over a period.
+     *
+     * @return Collection<int, object>
+     */
+    protected function topUsers(Project $project, string $type, string $countAlias, ?string $period = null, ?string $from = null, ?string $to = null)
+    {
+        return RecordUserBucket::query()
+            ->where('project_id', $project->id)
+            ->where('type', $type)
+            ->forPeriod($period, $from, $to)
+            ->select([
+                DB::raw($this->col('user_key').' as user_id'),
+                DB::raw($this->col('user_key').' as user_identifier'),
+                DB::raw("'' as user_email"),
+                DB::raw('SUM('.$this->col('count').') as '.$countAlias),
+                DB::raw('MAX('.$this->col('bucket').') as last_seen'),
+            ])
+            ->groupBy('user_key')
+            ->orderByDesc($countAlias)
+            ->limit(5)
+            ->get();
+    }
+
+    /**
+     * Distinct users seen for a type over a period.
+     */
+    protected function distinctUsers(Project $project, string $type, ?string $period = null, ?string $from = null, ?string $to = null): int
+    {
+        return RecordUserBucket::query()
+            ->where('project_id', $project->id)
+            ->where('type', $type)
+            ->forPeriod($period, $from, $to)
+            ->distinct()
+            ->count('user_key');
     }
 }

--- a/app/Services/RollupWriter.php
+++ b/app/Services/RollupWriter.php
@@ -1,0 +1,734 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Project;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Grammar;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Computes the dashboard's aggregates at write time.
+ */
+class RollupWriter
+{
+    /**
+     * Upper bounds of the latency histogram buckets, in microseconds.
+     */
+    public const LATENCY_BOUNDARIES = [1000, 5000, 10000, 25000, 50000, 100000, 250000, 500000, 1000000, 2500000, 5000000, 10000000];
+
+    /**
+     * Types whose users are tracked for distinct-user counts.
+     */
+    public const USER_TRACKED_TYPES = ['request', 'exception', 'query', 'queued-job'];
+
+    public const GROUP_USER_TYPES = ['exception'];
+
+    /**
+     * The prefix the client gives anonymous visitors instead of a null user.
+     */
+    public const GUEST_ID_PREFIX = 'guest_';
+
+    /**
+     * Counters that accumulate by addition.
+     *
+     * @return list<string>
+     */
+    public static function additiveColumns(): array
+    {
+        return array_merge([
+            'count',
+            'ok_count',
+            'client_error_count',
+            'server_error_count',
+            'neutral_count',
+            'hits',
+            'misses',
+            'writes',
+            'deletes',
+            'authed_count',
+            'sum_duration',
+            'count_duration',
+        ], static::latencyColumns());
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function latencyColumns(): array
+    {
+        $columns = array_map(fn (int $boundary) => 'lat_le_'.$boundary, static::LATENCY_BOUNDARIES);
+        $columns[] = 'lat_le_inf';
+
+        return $columns;
+    }
+
+    /**
+     * Fold a batch of ingested records into the rollup tables.
+     *
+     * @param  list<array{type: string, payload: array<string, mixed>, fingerprint: string|null, created_at: CarbonInterface}>  $batch
+     */
+    public function record(Project $project, array $batch): void
+    {
+        if ($batch === []) {
+            return;
+        }
+
+        $rollups = [];
+        $groups = [];
+        $groupUsers = [];
+        $userBuckets = [];
+        $ipBuckets = [];
+
+        foreach ($batch as $entry) {
+            $type = $entry['type'];
+            $payload = $entry['payload'];
+            $seenAt = $entry['created_at'];
+            $bucket = $this->bucketFor($seenAt);
+            $hour = $this->hourFor($seenAt);
+            $deltas = $this->deltasFor($type, $payload);
+
+            $key = $type.'@'.$bucket;
+            $rollups[$key] = $this->mergeDeltas(
+                $rollups[$key] ?? $this->emptyRow($project->id, $type, $bucket),
+                $deltas,
+            );
+
+            $fingerprint = $entry['fingerprint'] ?? null;
+
+            if ($fingerprint) {
+                $groupKey = $type.'@'.$hour.'@'.$fingerprint;
+                [$label, $sublabel] = $this->groupLabelsFor($type, $payload);
+
+                $groups[$groupKey] = $this->mergeDeltas(
+                    $groups[$groupKey] ?? $this->emptyGroupRow($project->id, $type, $hour, $fingerprint),
+                    $deltas,
+                );
+
+                $groups[$groupKey]['label'] = $label;
+                $groups[$groupKey]['sublabel'] = $sublabel;
+                $groups[$groupKey]['last_seen_at'] = max(
+                    $groups[$groupKey]['last_seen_at'] ?? '',
+                    $seenAt->format('Y-m-d H:i:s'),
+                );
+            }
+
+            $ip = $this->ipFor($payload);
+
+            if ($ip !== null) {
+                $ipRow = $type.'@'.$hour.'@'.$ip;
+
+                $ipBuckets[$ipRow] ??= [
+                    'project_id' => $project->id,
+                    'type' => $type,
+                    'bucket' => $hour,
+                    'ip' => $ip,
+                    'count' => 0,
+                ];
+
+                $ipBuckets[$ipRow]['count']++;
+            }
+
+            $userKey = $this->userKeyFor($type, $payload);
+
+            if ($userKey !== null && $fingerprint && in_array($type, static::GROUP_USER_TYPES, true)) {
+                $groupUsers[$type.'@'.$hour.'@'.$fingerprint.'@'.$userKey] = [
+                    'project_id' => $project->id,
+                    'type' => $type,
+                    'bucket' => $hour,
+                    'group_key' => $fingerprint,
+                    'user_key' => $userKey,
+                ];
+            }
+
+            if ($userKey !== null) {
+                $userRow = $type.'@'.$hour.'@'.$userKey;
+
+                $userBuckets[$userRow] ??= [
+                    'project_id' => $project->id,
+                    'type' => $type,
+                    'bucket' => $hour,
+                    'user_key' => $userKey,
+                    'count' => 0,
+                    'error_count' => 0,
+                    'last_seen_at' => null,
+                ];
+
+                $userBuckets[$userRow]['count']++;
+                $userBuckets[$userRow]['error_count'] += ($deltas['client_error_count'] ?? 0) + ($deltas['server_error_count'] ?? 0);
+                $userBuckets[$userRow]['last_seen_at'] = max(
+                    $userBuckets[$userRow]['last_seen_at'] ?? '',
+                    $seenAt->format('Y-m-d H:i:s'),
+                );
+            }
+        }
+
+        $this->upsertIncrement(
+            'record_rollups',
+            array_values($rollups),
+            conflict: ['project_id', 'type', 'bucket'],
+            additive: static::additiveColumns(),
+            maxColumns: ['max_duration'],
+            minColumns: ['min_duration'],
+        );
+
+        $this->upsertIncrement(
+            'record_group_rollups',
+            array_values($groups),
+            conflict: ['project_id', 'type', 'bucket', 'group_key'],
+            additive: static::additiveColumns(),
+            maxColumns: ['max_duration', 'last_seen_at'],
+            minColumns: ['min_duration'],
+            overwrite: ['label', 'sublabel'],
+        );
+
+        $this->upsertIncrement(
+            'record_user_buckets',
+            array_values($userBuckets),
+            conflict: ['project_id', 'type', 'bucket', 'user_key'],
+            additive: ['count', 'error_count'],
+            maxColumns: ['last_seen_at'],
+        );
+
+        $this->upsertIncrement(
+            'record_ip_buckets',
+            array_values($ipBuckets),
+            conflict: ['project_id', 'type', 'bucket', 'ip'],
+            additive: ['count'],
+        );
+
+        if ($groupUsers !== []) {
+            DB::table('record_group_user_buckets')->insertOrIgnore(array_values($groupUsers));
+        }
+    }
+
+    /**
+     * The two columns a list page shows for a group, by record type.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array{0: string|null, 1: string|null}
+     */
+    public function groupLabelsFor(string $type, array $payload): array
+    {
+        $first = fn (array $keys, ?string $fallback = null) => $this->firstString($payload, $keys) ?? $fallback;
+
+        [$label, $sublabel] = match ($type) {
+            'request' => [$first(['method'], 'GET'), $first(['route_path', 'path'], '/')],
+            'exception' => [$first(['class']), $first(['message'])],
+            'query' => [$first(['connection'], 'mysql'), $first(['sql'])],
+            'job-attempt', 'queued-job' => [$first(['name', 'job', 'job_class'], 'Unknown Job'), null],
+            'command' => [$first(['command', 'name'], 'Unknown Command'), null],
+            'scheduled-task' => [$first(['command', 'name'], 'Unknown Task'), $first(['cron', 'expression', 'schedule'])],
+            'outgoing-request' => [$first(['host']), null],
+            'cache-event' => [$first(['key']), $first(['store'])],
+            'notification' => [$first(['class']), $first(['channel'])],
+            'mail' => [$first(['class']), $first(['mailer'])],
+            default => [null, null],
+        };
+
+        return [
+            $label === null ? null : mb_substr($label, 0, 255),
+            $sublabel,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  list<string>  $keys
+     */
+    protected function firstString(array $payload, array $keys): ?string
+    {
+        foreach ($keys as $key) {
+            $value = $payload[$key] ?? null;
+
+            if (is_string($value) && $value !== '') {
+                return $value;
+            }
+
+            if (is_scalar($value) && ! is_bool($value)) {
+                return (string) $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Floor a timestamp to the minute it belongs to.
+     */
+    public function bucketFor(CarbonInterface $at): string
+    {
+        return $at->copy()->startOfMinute()->format('Y-m-d H:i:s');
+    }
+
+    /**
+     * Floor a timestamp to the hour, for the user buckets.
+     */
+    public function hourFor(CarbonInterface $at): string
+    {
+        return $at->copy()->startOfHour()->format('Y-m-d H:i:s');
+    }
+
+    /**
+     * The per-record contribution to its bucket's counters.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, float|int|null>
+     */
+    public function deltasFor(string $type, array $payload): array
+    {
+        $deltas = ['count' => 1];
+
+        $status = $this->resolvedStatusFor($type, $payload);
+
+        if ($status !== null) {
+            if ($status >= 500) {
+                $deltas['server_error_count'] = 1;
+            } elseif ($status >= 400) {
+                $deltas['client_error_count'] = 1;
+            } elseif ($status >= 100) {
+                $deltas['ok_count'] = 1;
+            }
+        }
+
+        if ($type === 'exception') {
+            $deltas['server_error_count'] = 1;
+        }
+
+        if ($type === 'job-attempt' || $type === 'queued-job') {
+            $this->applyJobStatus($deltas, $payload);
+        }
+
+        if ($type === 'command') {
+            $this->applyExitCode($deltas, $payload);
+        }
+
+        if ($type === 'scheduled-task') {
+            $this->applyScheduledTask($deltas, $payload);
+        }
+
+        if ($type === 'cache-event') {
+            $this->applyCacheType($deltas, $payload);
+        }
+
+        if ($type === 'notification' && $this->notificationFailed($payload)) {
+            $deltas['server_error_count'] = 1;
+        }
+
+        if ($type === 'mail' && ($payload['mailer'] ?? null) !== 'log') {
+            $deltas['ok_count'] = 1;
+        }
+
+        if ($type === 'request' && $this->userKeyFor($type, $payload) !== null) {
+            $deltas['authed_count'] = 1;
+        }
+
+        $duration = $this->numeric($payload['duration'] ?? null);
+
+        if ($duration !== null) {
+            $deltas['sum_duration'] = $duration;
+            $deltas['count_duration'] = 1;
+            $deltas['max_duration'] = $duration;
+            $deltas['min_duration'] = $duration;
+            $deltas[$this->latencyColumn($duration)] = 1;
+        }
+
+        return $deltas;
+    }
+
+    /**
+     * The distinct key for the user behind a record, or null when the record
+     * belongs to nobody.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    public function userKeyFor(string $type, array $payload): ?string
+    {
+        if (! in_array($type, static::USER_TRACKED_TYPES, true)) {
+            return null;
+        }
+
+        $user = $payload['user'] ?? null;
+
+        if (is_array($user)) {
+            $user = $user['id'] ?? null;
+        }
+
+        if ($user === null || $user === '') {
+            return null;
+        }
+
+        $user = (string) $user;
+
+        if (str_starts_with($user, static::GUEST_ID_PREFIX)) {
+            return null;
+        }
+
+        return substr($user, 0, 64);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function rawUserKeyFor(array $payload): ?string
+    {
+        $user = $payload['user'] ?? null;
+
+        if (is_array($user)) {
+            $user = $user['id'] ?? null;
+        }
+
+        if ($user === null || $user === '' || ! is_scalar($user)) {
+            return null;
+        }
+
+        return substr((string) $user, 0, 64);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function ipFor(array $payload): ?string
+    {
+        $ip = $payload['ip'] ?? null;
+
+        return is_string($ip) && $ip !== '' ? substr($ip, 0, 45) : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function traceIdFor(array $payload): ?string
+    {
+        $traceId = $payload['trace_id'] ?? null;
+
+        return is_string($traceId) && $traceId !== '' ? substr($traceId, 0, 64) : null;
+    }
+
+    /**
+     * The searchable text for the `records.message` FULLTEXT column.
+     *
+     * For logs the level is folded in, so searching "error" still finds
+     * error-level entries the way the old whole-payload LIKE did.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    public function messageFor(string $type, array $payload): ?string
+    {
+        $message = $payload['message'] ?? null;
+        $message = is_string($message) ? $message : '';
+
+        if ($type === 'log') {
+            $level = $payload['level'] ?? '';
+            $message = trim((is_string($level) ? $level : '').' '.$message);
+        }
+
+        return $message === '' ? null : mb_substr($message, 0, 1000);
+    }
+
+    /**
+     * The histogram column a duration falls into.
+     */
+    public function latencyColumn(float $milliseconds): string
+    {
+        foreach (static::LATENCY_BOUNDARIES as $boundary) {
+            if ($milliseconds <= $boundary) {
+                return 'lat_le_'.$boundary;
+            }
+        }
+
+        return 'lat_le_inf';
+    }
+
+    /**
+     * Add each row's counters onto its bucket, creating the bucket if absent.
+     *
+     * @param  list<array<string, mixed>>  $rows
+     * @param  list<string>  $conflict
+     * @param  list<string>  $additive
+     * @param  list<string>  $maxColumns
+     * @param  list<string>  $minColumns
+     * @param  list<string>  $overwrite
+     */
+    public function upsertIncrement(
+        string $table,
+        array $rows,
+        array $conflict,
+        array $additive,
+        array $maxColumns = [],
+        array $minColumns = [],
+        array $overwrite = [],
+    ): void {
+        if ($rows === []) {
+            return;
+        }
+
+        $connection = DB::connection();
+        $grammar = $connection->getQueryGrammar();
+        $columns = array_keys($rows[0]);
+
+        $wrapped = implode(', ', array_map(fn (string $column) => $grammar->wrap($column), $columns));
+        $tuple = '('.implode(', ', array_fill(0, count($columns), '?')).')';
+        $placeholders = implode(', ', array_fill(0, count($rows), $tuple));
+
+        $bindings = [];
+        foreach ($rows as $row) {
+            foreach ($columns as $column) {
+                $bindings[] = $row[$column];
+            }
+        }
+
+        $sql = 'insert into '.$grammar->wrap($table)." ({$wrapped}) values {$placeholders} "
+            .$this->conflictClause($connection->getDriverName(), $grammar, $table, $conflict, $additive, $maxColumns, $minColumns, $overwrite);
+
+        $connection->statement($sql, $bindings);
+    }
+
+    /**
+     * The driver-specific "add to the existing row" clause.
+     *
+     * @param  list<string>  $conflict
+     * @param  list<string>  $additive
+     * @param  list<string>  $maxColumns
+     * @param  list<string>  $minColumns
+     * @param  list<string>  $overwrite
+     */
+    protected function conflictClause(
+        string $driver,
+        Grammar $grammar,
+        string $table,
+        array $conflict,
+        array $additive,
+        array $maxColumns,
+        array $minColumns,
+        array $overwrite,
+    ): string {
+        $isMysql = $driver === 'mysql' || $driver === 'mariadb';
+
+        $incoming = $isMysql
+            ? fn (string $c) => 'values('.$grammar->wrap($c).')'
+            : fn (string $c) => 'excluded.'.$grammar->wrap($c);
+
+        $existing = $driver === 'pgsql'
+            ? fn (string $c) => $grammar->wrap($table).'.'.$grammar->wrap($c)
+            : fn (string $c) => $grammar->wrap($c);
+
+        $assignments = array_map(
+            fn (string $c) => $grammar->wrap($c).' = '.$existing($c).' + '.$incoming($c),
+            $additive,
+        );
+
+        foreach ($overwrite as $column) {
+            $assignments[] = $grammar->wrap($column).' = '.$incoming($column);
+        }
+
+        $maxFn = $isMysql || $driver === 'pgsql' ? 'greatest' : 'max';
+        $minFn = $isMysql || $driver === 'pgsql' ? 'least' : 'min';
+
+        foreach ($maxColumns as $column) {
+            $assignments[] = $grammar->wrap($column).' = '.($driver === 'pgsql'
+                ? $maxFn.'('.$existing($column).', '.$incoming($column).')'
+                : $this->nullSafeExtreme($grammar, $maxFn, $column, $existing, $incoming));
+        }
+
+        foreach ($minColumns as $column) {
+            $assignments[] = $grammar->wrap($column).' = '.($driver === 'pgsql'
+                ? $minFn.'('.$existing($column).', '.$incoming($column).')'
+                : $this->nullSafeExtreme($grammar, $minFn, $column, $existing, $incoming));
+        }
+
+        $target = implode(', ', array_map(fn (string $c) => $grammar->wrap($c), $conflict));
+
+        return $isMysql
+            ? 'on duplicate key update '.implode(', ', $assignments)
+            : "on conflict ({$target}) do update set ".implode(', ', $assignments);
+    }
+
+    /**
+     * `GREATEST(x, NULL)` is NULL on MySQL and SQLite; coalesce both sides.
+     *
+     * @param  callable(string): string  $existing
+     * @param  callable(string): string  $incoming
+     */
+    protected function nullSafeExtreme(Grammar $grammar, string $function, string $column, callable $existing, callable $incoming): string
+    {
+        $left = 'coalesce('.$existing($column).', '.$incoming($column).')';
+        $right = 'coalesce('.$incoming($column).', '.$existing($column).')';
+
+        return $function.'('.$left.', '.$right.')';
+    }
+
+    /**
+     * A zeroed rollup row, so every upsert binds the same column list.
+     *
+     * @return array<string, mixed>
+     */
+    protected function emptyRow(int $projectId, string $type, string $bucket): array
+    {
+        $row = [
+            'project_id' => $projectId,
+            'type' => $type,
+            'bucket' => $bucket,
+        ];
+
+        foreach (static::additiveColumns() as $column) {
+            $row[$column] = 0;
+        }
+
+        $row['max_duration'] = null;
+        $row['min_duration'] = null;
+
+        return $row;
+    }
+
+    /**
+     * A zeroed group row. Column order must be stable across the batch, since
+     * every row of one upsert binds the same column list.
+     *
+     * @return array<string, mixed>
+     */
+    protected function emptyGroupRow(int $projectId, string $type, string $hour, string $groupKey): array
+    {
+        $row = [
+            'project_id' => $projectId,
+            'type' => $type,
+            'bucket' => $hour,
+            'group_key' => $groupKey,
+            'label' => null,
+            'sublabel' => null,
+        ];
+
+        foreach (static::additiveColumns() as $column) {
+            $row[$column] = 0;
+        }
+
+        $row['max_duration'] = null;
+        $row['min_duration'] = null;
+        $row['last_seen_at'] = null;
+
+        return $row;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @param  array<string, float|int|null>  $deltas
+     * @return array<string, mixed>
+     */
+    protected function mergeDeltas(array $row, array $deltas): array
+    {
+        foreach ($deltas as $column => $value) {
+            if ($column === 'max_duration') {
+                $row[$column] = $row[$column] === null ? $value : max($row[$column], $value);
+            } elseif ($column === 'min_duration') {
+                $row[$column] = $row[$column] === null ? $value : min($row[$column], $value);
+            } else {
+                $row[$column] += $value;
+            }
+        }
+
+        return $row;
+    }
+
+    /**
+     * The HTTP status a record carries, if it has one.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    protected function resolvedStatusFor(string $type, array $payload): ?float
+    {
+        if ($type === 'request') {
+            return $this->numeric($payload['status_code'] ?? null);
+        }
+
+        if ($type === 'outgoing-request') {
+            return $this->numeric($payload['status_code'] ?? null) ?? $this->numeric($payload['status'] ?? null);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, float|int|null>  $deltas
+     * @param  array<string, mixed>  $payload
+     */
+    protected function applyJobStatus(array &$deltas, array $payload): void
+    {
+        match ($payload['status'] ?? null) {
+            'processed' => $deltas['ok_count'] = 1,
+            'failed' => $deltas['server_error_count'] = 1,
+            'released' => $deltas['neutral_count'] = 1,
+            default => null,
+        };
+    }
+
+    /**
+     * @param  array<string, float|int|null>  $deltas
+     * @param  array<string, mixed>  $payload
+     */
+    protected function applyExitCode(array &$deltas, array $payload): void
+    {
+        $exitCode = $this->numeric($payload['exit_code'] ?? null);
+
+        if ($exitCode === null) {
+            return;
+        }
+
+        if ((int) $exitCode === 0) {
+            $deltas['ok_count'] = 1;
+        } else {
+            $deltas['server_error_count'] = 1;
+        }
+    }
+
+    /**
+     * @param  array<string, float|int|null>  $deltas
+     * @param  array<string, mixed>  $payload
+     */
+    protected function applyScheduledTask(array &$deltas, array $payload): void
+    {
+        if (($payload['status'] ?? null) === 'skipped') {
+            $deltas['neutral_count'] = 1;
+
+            return;
+        }
+
+        $this->applyExitCode($deltas, $payload);
+    }
+
+    /**
+     * @param  array<string, float|int|null>  $deltas
+     * @param  array<string, mixed>  $payload
+     */
+    protected function applyCacheType(array &$deltas, array $payload): void
+    {
+        $cacheType = $payload['type'] ?? null;
+
+        if ($cacheType === 'hit') {
+            $deltas['hits'] = 1;
+            $deltas['ok_count'] = 1;
+        } elseif ($cacheType === 'miss') {
+            $deltas['misses'] = 1;
+            $deltas['server_error_count'] = 1;
+        } elseif ($cacheType === 'write') {
+            $deltas['writes'] = 1;
+        } elseif ($cacheType === 'delete') {
+            $deltas['deletes'] = 1;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    protected function notificationFailed(array $payload): bool
+    {
+        return ($payload['status'] ?? null) === 'failed' || ($payload['failed'] ?? false) === true;
+    }
+
+    /**
+     * Read a value only when it really is a number.
+     */
+    protected function numeric(mixed $value): ?float
+    {
+        return is_numeric($value) ? (float) $value : null;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "$schema": "https://getcomposer.org/schema.json",
     "name": "laraowl/laraowl",
     "type": "project",
-    "version": "1.0.8",
+    "version": "1.1.0",
     "description": "LaraOwl - The ultimate open-source, self-hosted monitoring platform for Laravel.",
     "keywords": [
         "laravel",

--- a/database/migrations/2026_07_09_202657_create_record_rollups_table.php
+++ b/database/migrations/2026_07_09_202657_create_record_rollups_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('record_rollups', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+            $table->string('type', 32);
+            $table->timestamp('bucket');
+            $table->unsignedBigInteger('count')->default(0);
+            $table->unsignedBigInteger('ok_count')->default(0);
+            $table->unsignedBigInteger('client_error_count')->default(0);
+            $table->unsignedBigInteger('server_error_count')->default(0);
+            $table->unsignedBigInteger('neutral_count')->default(0);
+            $table->unsignedBigInteger('hits')->default(0);
+            $table->unsignedBigInteger('misses')->default(0);
+            $table->unsignedBigInteger('writes')->default(0);
+            $table->unsignedBigInteger('deletes')->default(0);
+            $table->unsignedBigInteger('authed_count')->default(0);
+            $table->double('sum_duration')->default(0);
+            $table->unsignedBigInteger('count_duration')->default(0);
+            $table->double('max_duration')->nullable();
+            $table->double('min_duration')->nullable();
+
+            foreach (['1000', '5000', '10000', '25000', '50000', '100000', '250000', '500000', '1000000', '2500000', '5000000', '10000000', 'inf'] as $boundary) {
+                $table->unsignedBigInteger('lat_le_'.$boundary)->default(0);
+            }
+
+            $table->unique(['project_id', 'type', 'bucket'], 'record_rollups_unique');
+            $table->index(['project_id', 'bucket'], 'record_rollups_project_bucket_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('record_rollups');
+    }
+};

--- a/database/migrations/2026_07_09_202658_add_rollup_retention_days_to_projects_table.php
+++ b/database/migrations/2026_07_09_202658_add_rollup_retention_days_to_projects_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->integer('rollup_retention_days')->default(90)->after('retention_days');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dropColumn('rollup_retention_days');
+        });
+    }
+};

--- a/database/migrations/2026_07_09_202658_create_record_user_buckets_table.php
+++ b/database/migrations/2026_07_09_202658_create_record_user_buckets_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('record_user_buckets', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+            $table->string('type', 32);
+            $table->timestamp('bucket');
+            $table->string('user_key', 64);
+            $table->unsignedBigInteger('count')->default(0);
+            $table->unsignedBigInteger('error_count')->default(0);
+            $table->timestamp('last_seen_at')->nullable();
+
+            $table->unique(['project_id', 'type', 'bucket', 'user_key'], 'record_user_buckets_unique');
+            $table->index(['project_id', 'type', 'bucket'], 'record_user_buckets_lookup_idx');
+            $table->index(['project_id', 'user_key', 'bucket'], 'record_user_buckets_user_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('record_user_buckets');
+    }
+};

--- a/database/migrations/2026_07_10_140446_create_record_group_rollups_table.php
+++ b/database/migrations/2026_07_10_140446_create_record_group_rollups_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('record_group_rollups', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+            $table->string('type', 32);
+            $table->timestamp('bucket');
+            $table->string('group_key', 64);
+            $table->string('label', 255)->nullable();
+            $table->text('sublabel')->nullable();
+            $table->unsignedBigInteger('count')->default(0);
+            $table->unsignedBigInteger('ok_count')->default(0);
+            $table->unsignedBigInteger('client_error_count')->default(0);
+            $table->unsignedBigInteger('server_error_count')->default(0);
+            $table->unsignedBigInteger('neutral_count')->default(0);
+            $table->unsignedBigInteger('hits')->default(0);
+            $table->unsignedBigInteger('misses')->default(0);
+            $table->unsignedBigInteger('writes')->default(0);
+            $table->unsignedBigInteger('deletes')->default(0);
+            $table->unsignedBigInteger('authed_count')->default(0);
+            $table->double('sum_duration')->default(0);
+            $table->unsignedBigInteger('count_duration')->default(0);
+            $table->double('max_duration')->nullable();
+            $table->double('min_duration')->nullable();
+
+            foreach (['1000', '5000', '10000', '25000', '50000', '100000', '250000', '500000', '1000000', '2500000', '5000000', '10000000', 'inf'] as $boundary) {
+                $table->unsignedBigInteger('lat_le_'.$boundary)->default(0);
+            }
+
+            $table->timestamp('last_seen_at')->nullable();
+
+            $table->unique(['project_id', 'type', 'bucket', 'group_key'], 'record_group_rollups_unique');
+            $table->index(['project_id', 'type', 'bucket'], 'record_group_rollups_lookup_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('record_group_rollups');
+    }
+};

--- a/database/migrations/2026_07_10_141018_create_record_group_user_buckets_table.php
+++ b/database/migrations/2026_07_10_141018_create_record_group_user_buckets_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('record_group_user_buckets', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+            $table->string('type', 32);
+            $table->timestamp('bucket');
+            $table->string('group_key', 64);
+            $table->string('user_key', 64);
+
+            $table->unique(['project_id', 'type', 'bucket', 'group_key', 'user_key'], 'record_group_user_buckets_unique');
+            $table->index(['project_id', 'type', 'group_key'], 'record_group_user_buckets_group_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('record_group_user_buckets');
+    }
+};

--- a/database/migrations/2026_07_10_145224_optimise_records_table_for_lookups.php
+++ b/database/migrations/2026_07_10_145224_optimise_records_table_for_lookups.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('records', function (Blueprint $table) {
+            $table->string('user_key', 64)->nullable()->after('fingerprint');
+            $table->string('ip', 45)->nullable()->after('user_key');
+        });
+
+        Schema::table('records', function (Blueprint $table) {
+            $table->dropIndex('records_type_index');
+            $table->dropIndex('records_created_at_index');
+            $table->dropIndex('records_fingerprint_index');
+
+            $table->index(['project_id', 'fingerprint', 'created_at'], 'records_project_fingerprint_created_idx');
+
+            $table->index(['project_id', 'user_key', 'created_at'], 'records_project_user_created_idx');
+
+            $table->index(['project_id', 'type', 'created_at', 'ip'], 'records_project_type_created_ip_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('records', function (Blueprint $table) {
+            $table->dropIndex('records_project_type_created_ip_idx');
+            $table->dropIndex('records_project_user_created_idx');
+            $table->dropIndex('records_project_fingerprint_created_idx');
+
+            $table->index('type');
+            $table->index('created_at');
+            $table->index('fingerprint');
+        });
+
+        Schema::table('records', function (Blueprint $table) {
+            $table->dropColumn(['user_key', 'ip']);
+        });
+    }
+};

--- a/database/migrations/2026_07_10_152556_create_record_ip_buckets_table.php
+++ b/database/migrations/2026_07_10_152556_create_record_ip_buckets_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('record_ip_buckets', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+            $table->string('type', 32);
+            $table->timestamp('bucket');
+            $table->string('ip', 45);
+            $table->unsignedBigInteger('count')->default(0);
+
+            $table->unique(['project_id', 'type', 'bucket', 'ip'], 'record_ip_buckets_unique');
+            $table->index(['project_id', 'type', 'bucket'], 'record_ip_buckets_lookup_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('record_ip_buckets');
+    }
+};

--- a/database/migrations/2026_07_10_160143_add_trace_id_to_records_table.php
+++ b/database/migrations/2026_07_10_160143_add_trace_id_to_records_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('records', function (Blueprint $table) {
+            $table->string('trace_id', 64)->nullable()->after('ip');
+            $table->index(['project_id', 'trace_id'], 'records_project_trace_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('records', function (Blueprint $table) {
+            $table->dropIndex('records_project_trace_idx');
+            $table->dropColumn('trace_id');
+        });
+    }
+};

--- a/database/migrations/2026_07_10_183740_add_message_fulltext_to_records_table.php
+++ b/database/migrations/2026_07_10_183740_add_message_fulltext_to_records_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Give log search something to stand on.
+     *
+     * Searching logs ran `payload LIKE '%term%'` over the whole JSON column — a
+     * leading-wildcard scan that reads every log record's full payload. This
+     * lifts the searchable text into a `message` column and indexes it FULLTEXT,
+     * so search becomes an index lookup on MySQL/MariaDB and PostgreSQL.
+     *
+     * SQLite (used by the test suite) has no FULLTEXT index on ordinary columns,
+     * so the index is created only where supported; the read path falls back to
+     * LIKE on the same narrow column there.
+     */
+    public function up(): void
+    {
+        Schema::table('records', function (Blueprint $table) {
+            $table->string('message', 1000)->nullable()->after('trace_id');
+        });
+
+        if ($this->supportsFullText()) {
+            Schema::table('records', function (Blueprint $table) {
+                $table->fullText('message', 'records_message_fulltext');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if ($this->supportsFullText()) {
+            Schema::table('records', function (Blueprint $table) {
+                $table->dropFullText('records_message_fulltext');
+            });
+        }
+
+        Schema::table('records', function (Blueprint $table) {
+            $table->dropColumn('message');
+        });
+    }
+
+    protected function supportsFullText(): bool
+    {
+        return in_array(DB::connection()->getDriverName(), ['mysql', 'mariadb', 'pgsql'], true);
+    }
+};

--- a/resources/js/components/pagination.tsx
+++ b/resources/js/components/pagination.tsx
@@ -6,10 +6,49 @@ import {
     ChevronsRight,
 } from 'lucide-react';
 
-export function Pagination({ links, meta }: { links: any; meta: any }) {
+/**
+ * `meta` is the Laravel paginator. Its navigation URLs live on the paginator
+ * itself (`first_page_url`, `prev_page_url`, ...); the `links` array only holds
+ * the numbered page links. The chevrons used to read `links.first`/`links.prev`,
+ * which do not exist on that array, so First/Prev/Next/Last never worked.
+ */
+export function Pagination({ meta }: { links?: any; meta: any }) {
     if (!meta || meta.last_page <= 1) {
         return null;
     }
+
+    const numberedLinks = (meta.links || []).filter(
+        (l: any) => !isNaN(Number(l.label)),
+    );
+
+    const arrow = (url: string | null, icon: React.ReactNode, key: string) => {
+        const className =
+            'rounded p-1.5 transition-colors hover:bg-white/10 flex items-center justify-center';
+
+        if (!url) {
+            return (
+                <span
+                    key={key}
+                    className={`${className} cursor-not-allowed opacity-30`}
+                    aria-disabled="true"
+                >
+                    {icon}
+                </span>
+            );
+        }
+
+        return (
+            <Link
+                key={key}
+                href={url}
+                preserveScroll
+                preserveState
+                className={className}
+            >
+                {icon}
+            </Link>
+        );
+    };
 
     return (
         <div className="flex items-center justify-between gap-4 border-t border-border bg-white/[0.01] p-4">
@@ -18,52 +57,41 @@ export function Pagination({ links, meta }: { links: any; meta: any }) {
             </div>
 
             <div className="flex items-center gap-1">
-                {/* First Page */}
-                <Link
-                    href={links.first}
-                    className={`rounded p-1.5 transition-colors hover:bg-white/10 ${!links.prev ? 'cursor-not-allowed opacity-30' : ''}`}
-                >
-                    <ChevronsLeft className="h-4 w-4" />
-                </Link>
+                {arrow(
+                    meta.first_page_url,
+                    <ChevronsLeft className="h-4 w-4" />,
+                    'first',
+                )}
+                {arrow(
+                    meta.prev_page_url,
+                    <ChevronLeft className="h-4 w-4" />,
+                    'prev',
+                )}
 
-                {/* Previous Page */}
-                <Link
-                    href={links.prev}
-                    className={`rounded p-1.5 transition-colors hover:bg-white/10 ${!links.prev ? 'cursor-not-allowed opacity-30' : ''}`}
-                >
-                    <ChevronLeft className="h-4 w-4" />
-                </Link>
-
-                {/* Page Numbers */}
                 <div className="mx-2 flex items-center gap-1">
-                    {meta.links
-                        .filter((l: any) => !isNaN(Number(l.label)))
-                        .map((link: any) => (
-                            <Link
-                                key={link.label}
-                                href={link.url}
-                                className={`flex h-7 min-w-[28px] items-center justify-center rounded text-xs font-bold transition-all ${link.active ? 'border border-border bg-white/10 text-foreground' : 'text-gray-500 hover:bg-muted hover:text-foreground'}`}
-                            >
-                                {link.label}
-                            </Link>
-                        ))}
+                    {numberedLinks.map((link: any) => (
+                        <Link
+                            key={link.label}
+                            href={link.url}
+                            preserveScroll
+                            preserveState
+                            className={`flex h-7 min-w-[28px] items-center justify-center rounded text-xs font-bold transition-all ${link.active ? 'border border-border bg-white/10 text-foreground' : 'text-gray-500 hover:bg-muted hover:text-foreground'}`}
+                        >
+                            {link.label}
+                        </Link>
+                    ))}
                 </div>
 
-                {/* Next Page */}
-                <Link
-                    href={links.next}
-                    className={`rounded p-1.5 transition-colors hover:bg-white/10 ${!links.next ? 'cursor-not-allowed opacity-30' : ''}`}
-                >
-                    <ChevronRight className="h-4 w-4" />
-                </Link>
-
-                {/* Last Page */}
-                <Link
-                    href={links.last}
-                    className={`rounded p-1.5 transition-colors hover:bg-white/10 ${!links.next ? 'cursor-not-allowed opacity-30' : ''}`}
-                >
-                    <ChevronsRight className="h-4 w-4" />
-                </Link>
+                {arrow(
+                    meta.next_page_url,
+                    <ChevronRight className="h-4 w-4" />,
+                    'next',
+                )}
+                {arrow(
+                    meta.last_page_url,
+                    <ChevronsRight className="h-4 w-4" />,
+                    'last',
+                )}
             </div>
         </div>
     );

--- a/resources/js/hooks/use-live-reload.ts
+++ b/resources/js/hooks/use-live-reload.ts
@@ -1,0 +1,57 @@
+import { router } from '@inertiajs/react';
+import { useEffect, useRef } from 'react';
+
+export function useLiveReload(
+    projectId: number | string | undefined,
+    intervalMs = 5000,
+): void {
+    const lastReloadAt = useRef(0);
+    const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        if (!projectId || !window.Echo) {
+            return;
+        }
+
+        const reload = () => {
+            lastReloadAt.current = Date.now();
+            router.reload({ preserveScroll: true, preserveState: true } as any);
+        };
+
+        const schedule = () => {
+            const elapsed = Date.now() - lastReloadAt.current;
+
+            if (elapsed >= intervalMs) {
+                if (timer.current) {
+                    clearTimeout(timer.current);
+                    timer.current = null;
+                }
+
+                reload();
+
+                return;
+            }
+
+            if (!timer.current) {
+                timer.current = setTimeout(() => {
+                    timer.current = null;
+                    reload();
+                }, intervalMs - elapsed);
+            }
+        };
+
+        const channel = window.Echo.private(`project.${projectId}`).listen(
+            '.ProjectDataIngested',
+            schedule,
+        );
+
+        return () => {
+            if (timer.current) {
+                clearTimeout(timer.current);
+                timer.current = null;
+            }
+
+            channel.stopListening('.ProjectDataIngested');
+        };
+    }, [projectId, intervalMs]);
+}

--- a/resources/js/pages/dashboard/index.tsx
+++ b/resources/js/pages/dashboard/index.tsx
@@ -1,4 +1,4 @@
-import { Head, usePage, Link, router } from '@inertiajs/react';
+﻿import { Head, usePage, Link } from '@inertiajs/react';
 import { formatDistanceToNow } from 'date-fns';
 import {
     Activity as ActivityIcon,
@@ -9,7 +9,6 @@ import {
     Plus,
     Settings2,
 } from 'lucide-react';
-import { useEffect } from 'react';
 import {
     AreaChart,
     Area,
@@ -22,6 +21,7 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { useLiveReload } from '@/hooks/use-live-reload';
 import AppLayout from '@/layouts/app-layout';
 import { appendMonitoringQuery } from '@/lib/monitoring-query';
 import { formatMicroSeconds, formatCompactNumber } from '@/lib/utils';
@@ -53,21 +53,7 @@ export default function Dashboard({
             to,
         });
 
-    useEffect(() => {
-        if (!currentProject?.id || !window.Echo) {
-            return;
-        }
-
-        const channel = window.Echo.private(
-            `project.${currentProject.id}`,
-        ).listen('.ProjectDataIngested', () => {
-            router.reload({ preserveScroll: true, preserveState: true } as any);
-        });
-
-        return () => {
-            channel.stopListening('.ProjectDataIngested');
-        };
-    }, [currentProject?.id]);
+    useLiveReload(currentProject?.id);
 
     return (
         <>

--- a/resources/js/pages/projects/cache/index.tsx
+++ b/resources/js/pages/projects/cache/index.tsx
@@ -1,6 +1,5 @@
-import { Head, router, usePage } from '@inertiajs/react';
+﻿import { Head, usePage } from '@inertiajs/react';
 import { Database, Layers, FileCode } from 'lucide-react';
-import { useEffect } from 'react';
 import { BarChart, Bar, ResponsiveContainer, Tooltip, XAxis } from 'recharts';
 import { EmptyState } from '@/components/empty-state';
 import { Pagination } from '@/components/pagination';
@@ -13,6 +12,7 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
+import { useLiveReload } from '@/hooks/use-live-reload';
 import AppLayout from '@/layouts/app-layout';
 import { formatCompactNumber } from '@/lib/utils';
 
@@ -28,21 +28,7 @@ export default function CacheIndex({
     const { props }: any = usePage();
     const currentProject = props.current_project || props.currentProject;
 
-    useEffect(() => {
-        if (!currentProject?.id || !window.Echo) {
-            return;
-        }
-
-        const channel = window.Echo.private(
-            `project.${currentProject.id}`,
-        ).listen('.ProjectDataIngested', () => {
-            router.reload({ preserveScroll: true, preserveState: true } as any);
-        });
-
-        return () => {
-            channel.stopListening('.ProjectDataIngested');
-        };
-    }, [currentProject?.id]);
+    useLiveReload(currentProject?.id);
 
     const data = keys.data || [];
     const totalWrites = data.reduce(

--- a/resources/js/pages/projects/commands/index.tsx
+++ b/resources/js/pages/projects/commands/index.tsx
@@ -1,6 +1,5 @@
-import { Head, Link, usePage, router } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { Terminal, ArrowUpRight, XCircle, LayoutGrid } from 'lucide-react';
-import { useEffect } from 'react';
 import {
     BarChart,
     Bar,
@@ -21,6 +20,7 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
+import { useLiveReload } from '@/hooks/use-live-reload';
 import AppLayout from '@/layouts/app-layout';
 import { monitoringQuery } from '@/lib/monitoring-query';
 import { formatMicroSeconds, formatCompactNumber } from '@/lib/utils';
@@ -47,21 +47,7 @@ export default function CommandsIndex({
     const projectSlug =
         props.current_project?.slug || props.currentProject?.slug;
 
-    useEffect(() => {
-        if (!currentProject?.id || !window.Echo) {
-            return;
-        }
-
-        const channel = window.Echo.private(
-            `project.${currentProject.id}`,
-        ).listen('.ProjectDataIngested', () => {
-            router.reload({ preserveScroll: true, preserveState: true } as any);
-        });
-
-        return () => {
-            channel.stopListening('.ProjectDataIngested');
-        };
-    }, [currentProject?.id]);
+    useLiveReload(currentProject?.id);
 
     const data = commands.data || [];
     const commandDetailsHref = (hash: string | number) =>

--- a/resources/js/pages/projects/commands/show.tsx
+++ b/resources/js/pages/projects/commands/show.tsx
@@ -1,5 +1,6 @@
-import { Head, Link, usePage } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { Terminal, Search, ArrowUpRight, Activity } from 'lucide-react';
+import { Pagination } from '@/components/pagination';
 import { Badge } from '@/components/ui/badge';
 import {
     Table,
@@ -148,6 +149,7 @@ export default function CommandShow({
                                 ))}
                             </TableBody>
                         </Table>
+                        <Pagination links={records.links} meta={records} />
                     </div>
                 </div>
             </div>

--- a/resources/js/pages/projects/exceptions/index.tsx
+++ b/resources/js/pages/projects/exceptions/index.tsx
@@ -1,6 +1,5 @@
-import { Head, Link, usePage, router } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { AlertCircle, ArrowUpRight } from 'lucide-react';
-import { useEffect } from 'react';
 import { BarChart, Bar, ResponsiveContainer, Tooltip, XAxis } from 'recharts';
 import { EmptyState } from '@/components/empty-state';
 import { Pagination } from '@/components/pagination';
@@ -14,6 +13,7 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
+import { useLiveReload } from '@/hooks/use-live-reload';
 import AppLayout from '@/layouts/app-layout';
 import { monitoringQuery } from '@/lib/monitoring-query';
 import { formatCompactNumber } from '@/lib/utils';
@@ -41,21 +41,7 @@ export default function ExceptionsIndex({
     const projectSlug =
         props.current_project?.slug || props.currentProject?.slug;
 
-    useEffect(() => {
-        if (!currentProject?.id || !window.Echo) {
-            return;
-        }
-
-        const channel = window.Echo.private(
-            `project.${currentProject.id}`,
-        ).listen('.ProjectDataIngested', () => {
-            router.reload({ preserveScroll: true, preserveState: true } as any);
-        });
-
-        return () => {
-            channel.stopListening('.ProjectDataIngested');
-        };
-    }, [currentProject?.id]);
+    useLiveReload(currentProject?.id);
 
     const data = exceptions.data || [];
     const exceptionDetailsHref = (hash: string | number) =>

--- a/resources/js/pages/projects/exceptions/show.tsx
+++ b/resources/js/pages/projects/exceptions/show.tsx
@@ -1,6 +1,7 @@
-import { Head, Link, usePage } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { ArrowUpRight, ChevronDown } from 'lucide-react';
 import { useState } from 'react';
+import { Pagination } from '@/components/pagination';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
 import {
@@ -266,6 +267,7 @@ export default function ExceptionDetails({
                                 ))}
                             </TableBody>
                         </Table>
+                        <Pagination links={records.links} meta={records} />
                     </div>
                 </div>
             </div>

--- a/resources/js/pages/projects/issues/index.tsx
+++ b/resources/js/pages/projects/issues/index.tsx
@@ -1,4 +1,4 @@
-import { Head, usePage, router } from '@inertiajs/react';
+﻿import { Head, usePage, router } from '@inertiajs/react';
 import {
     Search,
     TrendingUp,
@@ -20,6 +20,7 @@ import { EmptyState } from '@/components/empty-state';
 import { IssueTable } from '@/components/issue-table';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { useLiveReload } from '@/hooks/use-live-reload';
 import AppLayout from '@/layouts/app-layout';
 import { formatCompactNumber } from '@/lib/utils';
 
@@ -44,21 +45,7 @@ export default function Issues({
 
     const [search, setSearch] = useState(filters.search || '');
 
-    useEffect(() => {
-        if (!currentProject?.id || !window.Echo) {
-            return;
-        }
-
-        const channel = window.Echo.private(
-            `project.${currentProject.id}`,
-        ).listen('.ProjectDataIngested', () => {
-            router.reload({ preserveScroll: true, preserveState: true } as any);
-        });
-
-        return () => {
-            channel.stopListening('.ProjectDataIngested');
-        };
-    }, [currentProject?.id]);
+    useLiveReload(currentProject?.id);
     const [view, setView] = useState('exceptions'); // 'exceptions' or 'performance'
 
     const data = issues.data || [];

--- a/resources/js/pages/projects/jobs/index.tsx
+++ b/resources/js/pages/projects/jobs/index.tsx
@@ -1,6 +1,5 @@
-import { Head, Link, usePage, router } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { ArrowUpRight, XCircle, Cpu, Zap } from 'lucide-react';
-import { useEffect } from 'react';
 import {
     BarChart,
     Bar,
@@ -21,6 +20,7 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
+import { useLiveReload } from '@/hooks/use-live-reload';
 import AppLayout from '@/layouts/app-layout';
 import { monitoringQuery } from '@/lib/monitoring-query';
 import { formatMicroSeconds, formatCompactNumber } from '@/lib/utils';
@@ -47,21 +47,7 @@ export default function JobsIndex({
     const projectSlug =
         props.current_project?.slug || props.currentProject?.slug;
 
-    useEffect(() => {
-        if (!currentProject?.id || !window.Echo) {
-            return;
-        }
-
-        const channel = window.Echo.private(
-            `project.${currentProject.id}`,
-        ).listen('.ProjectDataIngested', () => {
-            router.reload({ preserveScroll: true, preserveState: true } as any);
-        });
-
-        return () => {
-            channel.stopListening('.ProjectDataIngested');
-        };
-    }, [currentProject?.id]);
+    useLiveReload(currentProject?.id);
 
     const data = jobs.data || [];
     const jobDetailsHref = (hash: string | number) =>

--- a/resources/js/pages/projects/jobs/show.tsx
+++ b/resources/js/pages/projects/jobs/show.tsx
@@ -1,5 +1,6 @@
-import { Head, Link, usePage } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { ArrowUpRight, Zap } from 'lucide-react';
+import { Pagination } from '@/components/pagination';
 import { Badge } from '@/components/ui/badge';
 import {
     Table,
@@ -123,6 +124,7 @@ export default function JobShow({
                             ))}
                         </TableBody>
                     </Table>
+                    <Pagination links={records.links} meta={records} />
                 </div>
             </div>
         </>

--- a/resources/js/pages/projects/logs/index.tsx
+++ b/resources/js/pages/projects/logs/index.tsx
@@ -1,6 +1,6 @@
-import { Head, Link, usePage, router } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { ArrowUpRight, X, Terminal, Globe, FileText } from 'lucide-react';
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { EmptyState } from '@/components/empty-state';
@@ -14,6 +14,7 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
+import { useLiveReload } from '@/hooks/use-live-reload';
 import AppLayout from '@/layouts/app-layout';
 import { formatCompactNumber, formatValue } from '@/lib/utils';
 import { show as showRecord } from '@/routes/records';
@@ -37,21 +38,7 @@ export default function LogsIndex({ records }: { records: any }) {
             { mergeQuery: {} },
         );
 
-    useEffect(() => {
-        if (!currentProject?.id || !window.Echo) {
-            return;
-        }
-
-        const channel = window.Echo.private(
-            `project.${currentProject.id}`,
-        ).listen('.ProjectDataIngested', () => {
-            router.reload({ preserveScroll: true, preserveState: true } as any);
-        });
-
-        return () => {
-            channel.stopListening('.ProjectDataIngested');
-        };
-    }, [currentProject?.id]);
+    useLiveReload(currentProject?.id);
 
     const getLevelColor = (level: string) => {
         const l = level.toLowerCase();

--- a/resources/js/pages/projects/mail/index.tsx
+++ b/resources/js/pages/projects/mail/index.tsx
@@ -1,6 +1,5 @@
-import { Head, Link, usePage, router } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { ArrowUpRight, Inbox } from 'lucide-react';
-import { useEffect } from 'react';
 import { EmptyState } from '@/components/empty-state';
 import { Pagination } from '@/components/pagination';
 import { Badge } from '@/components/ui/badge';
@@ -12,6 +11,7 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
+import { useLiveReload } from '@/hooks/use-live-reload';
 import AppLayout from '@/layouts/app-layout';
 import { monitoringQuery } from '@/lib/monitoring-query';
 import { show as showMail } from '@/routes/mail';
@@ -33,21 +33,7 @@ export default function MailIndex({
     const projectSlug =
         props.current_project?.slug || props.currentProject?.slug;
 
-    useEffect(() => {
-        if (!currentProject?.id || !window.Echo) {
-            return;
-        }
-
-        const channel = window.Echo.private(
-            `project.${currentProject.id}`,
-        ).listen('.ProjectDataIngested', () => {
-            router.reload({ preserveScroll: true, preserveState: true } as any);
-        });
-
-        return () => {
-            channel.stopListening('.ProjectDataIngested');
-        };
-    }, [currentProject?.id]);
+    useLiveReload(currentProject?.id);
 
     const data = mailables.data || [];
     const mailDetailsHref = (hash: string | number) =>

--- a/resources/js/pages/projects/mail/show.tsx
+++ b/resources/js/pages/projects/mail/show.tsx
@@ -1,5 +1,6 @@
-import { Head, Link, usePage } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { ArrowUpRight, Mail } from 'lucide-react';
+import { Pagination } from '@/components/pagination';
 import { Badge } from '@/components/ui/badge';
 import {
     Table,
@@ -129,6 +130,7 @@ export default function MailShow({
                             ))}
                         </TableBody>
                     </Table>
+                    <Pagination links={records.links} meta={records} />
                 </div>
             </div>
         </>

--- a/resources/js/pages/projects/notifications/index.tsx
+++ b/resources/js/pages/projects/notifications/index.tsx
@@ -1,4 +1,4 @@
-import { Head, Link, usePage, router } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import {
     Bell,
     ArrowUpRight,
@@ -9,7 +9,6 @@ import {
     XCircle,
     Send,
 } from 'lucide-react';
-import { useEffect } from 'react';
 import { EmptyState } from '@/components/empty-state';
 import { Pagination } from '@/components/pagination';
 import {
@@ -20,6 +19,7 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
+import { useLiveReload } from '@/hooks/use-live-reload';
 import AppLayout from '@/layouts/app-layout';
 import { monitoringQuery } from '@/lib/monitoring-query';
 import { formatCompactNumber } from '@/lib/utils';
@@ -42,21 +42,7 @@ export default function NotificationsIndex({
     const projectSlug =
         props.current_project?.slug || props.currentProject?.slug;
 
-    useEffect(() => {
-        if (!currentProject?.id || !window.Echo) {
-            return;
-        }
-
-        const channel = window.Echo.private(
-            `project.${currentProject.id}`,
-        ).listen('.ProjectDataIngested', () => {
-            router.reload({ preserveScroll: true, preserveState: true } as any);
-        });
-
-        return () => {
-            channel.stopListening('.ProjectDataIngested');
-        };
-    }, [currentProject?.id]);
+    useLiveReload(currentProject?.id);
 
     const data = notifications.data || [];
     const notificationDetailsHref = (hash: string | number) =>

--- a/resources/js/pages/projects/notifications/show.tsx
+++ b/resources/js/pages/projects/notifications/show.tsx
@@ -1,5 +1,6 @@
-import { Head, Link, usePage } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { ArrowUpRight, Bell } from 'lucide-react';
+import { Pagination } from '@/components/pagination';
 import { Badge } from '@/components/ui/badge';
 import {
     Table,
@@ -117,6 +118,7 @@ export default function NotificationShow({
                             ))}
                         </TableBody>
                     </Table>
+                    <Pagination links={records.links} meta={records} />
                 </div>
             </div>
         </>

--- a/resources/js/pages/projects/outgoing-requests/index.tsx
+++ b/resources/js/pages/projects/outgoing-requests/index.tsx
@@ -1,6 +1,5 @@
-import { Head, Link, usePage, router } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { Globe, ArrowUpRight } from 'lucide-react';
-import { useEffect } from 'react';
 import {
     BarChart,
     Bar,
@@ -21,6 +20,7 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
+import { useLiveReload } from '@/hooks/use-live-reload';
 import AppLayout from '@/layouts/app-layout';
 import { monitoringQuery } from '@/lib/monitoring-query';
 import { formatMicroSeconds, formatCompactNumber } from '@/lib/utils';
@@ -47,21 +47,7 @@ export default function OutgoingRequestsIndex({
     const projectSlug =
         props.current_project?.slug || props.currentProject?.slug;
 
-    useEffect(() => {
-        if (!currentProject?.id || !window.Echo) {
-            return;
-        }
-
-        const channel = window.Echo.private(
-            `project.${currentProject.id}`,
-        ).listen('.ProjectDataIngested', () => {
-            router.reload({ preserveScroll: true, preserveState: true } as any);
-        });
-
-        return () => {
-            channel.stopListening('.ProjectDataIngested');
-        };
-    }, [currentProject?.id]);
+    useLiveReload(currentProject?.id);
 
     const data = hosts.data || [];
     const outgoingRequestDetailsHref = (hash: string | number) =>

--- a/resources/js/pages/projects/outgoing-requests/show.tsx
+++ b/resources/js/pages/projects/outgoing-requests/show.tsx
@@ -1,5 +1,6 @@
-import { Head, Link, usePage } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { Globe, Search, ArrowUpRight, Activity } from 'lucide-react';
+import { Pagination } from '@/components/pagination';
 import { Badge } from '@/components/ui/badge';
 import {
     Table,
@@ -154,6 +155,7 @@ export default function OutgoingRequestShow({
                                 ))}
                             </TableBody>
                         </Table>
+                        <Pagination links={records.links} meta={records} />
                     </div>
                 </div>
             </div>

--- a/resources/js/pages/projects/queries/index.tsx
+++ b/resources/js/pages/projects/queries/index.tsx
@@ -1,6 +1,5 @@
-import { Head, Link, usePage, router } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { Database, ArrowUpRight, FileCode } from 'lucide-react';
-import { useEffect } from 'react';
 import {
     BarChart,
     Bar,
@@ -21,6 +20,7 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
+import { useLiveReload } from '@/hooks/use-live-reload';
 import AppLayout from '@/layouts/app-layout';
 import { monitoringQuery } from '@/lib/monitoring-query';
 import { formatMicroSeconds, formatCompactNumber } from '@/lib/utils';
@@ -48,21 +48,7 @@ export default function QueriesIndex({
     const projectSlug =
         props.current_project?.slug || props.currentProject?.slug;
 
-    useEffect(() => {
-        if (!currentProject?.id || !window.Echo) {
-            return;
-        }
-
-        const channel = window.Echo.private(
-            `project.${currentProject.id}`,
-        ).listen('.ProjectDataIngested', () => {
-            router.reload({ preserveScroll: true, preserveState: true } as any);
-        });
-
-        return () => {
-            channel.stopListening('.ProjectDataIngested');
-        };
-    }, [currentProject?.id]);
+    useLiveReload(currentProject?.id);
 
     const data = queries.data || [];
     const queryDetailsHref = (hash: string | number) =>

--- a/resources/js/pages/projects/queries/show.tsx
+++ b/resources/js/pages/projects/queries/show.tsx
@@ -1,5 +1,6 @@
-import { Head, Link, usePage } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { Database, Search, ArrowUpRight, Layers } from 'lucide-react';
+import { Pagination } from '@/components/pagination';
 import { Badge } from '@/components/ui/badge';
 import {
     Table,
@@ -158,6 +159,7 @@ export default function QueryDetails({
                                 ))}
                             </TableBody>
                         </Table>
+                        <Pagination links={records.links} meta={records} />
                     </div>
                 </div>
             </div>

--- a/resources/js/pages/projects/records/show.tsx
+++ b/resources/js/pages/projects/records/show.tsx
@@ -28,6 +28,7 @@ export default function RecordShow({
     usePage();
     const payload = record.payload || {};
     const [expandedHeaders, setExpandedHeaders] = useState(false);
+    const [expandedPayload, setExpandedPayload] = useState(false);
 
     const getStatusColor = (status: number) => {
         if (status >= 500) {
@@ -42,13 +43,19 @@ export default function RecordShow({
     };
 
     const queries = relatedRecords.filter((r) => r.type === 'query');
-    const logs = relatedRecords.filter((r) => r.type === 'log');
+
+    const countOf = (value: unknown) =>
+        typeof value === 'number'
+            ? value
+            : Array.isArray(value)
+              ? value.length
+              : 0;
 
     const events = [
         {
             label: 'QUERIES',
             icon: Database,
-            count: queries.length,
+            count: countOf(payload.queries),
             duration:
                 queries.reduce((acc, r) => acc + (r.payload.duration || 0), 0) /
                 1000,
@@ -56,34 +63,55 @@ export default function RecordShow({
         {
             label: 'MAIL',
             icon: Mail,
-            count: payload.mail_count || 0,
+            count: countOf(payload.mail),
             duration: 0,
         },
         {
             label: 'CACHE',
             icon: Layers,
-            count: payload.cache_count || 0,
+            count: countOf(payload.cache_events),
             duration: 0,
         },
         {
             label: 'OUTGOING REQUESTS',
             icon: Globe,
-            count: payload.outgoing_count || 0,
+            count: countOf(payload.outgoing_requests),
             duration: 0,
         },
         {
             label: 'NOTIFICATIONS',
             icon: Bell,
-            count: payload.notification_count || 0,
+            count: countOf(payload.notifications),
             duration: 0,
         },
         {
             label: 'QUEUED JOBS',
             icon: Activity,
-            count: payload.job_count || 0,
+            count: countOf(payload.jobs_queued),
             duration: 0,
         },
     ];
+
+    const totalEvents = events.reduce((acc, event) => acc + event.count, 0);
+
+    const subLabel = (sub: any) => {
+        const p = sub.payload || {};
+
+        switch (sub.type) {
+            case 'query':
+                return p.sql;
+            case 'outgoing-request':
+                return p.url || p.host;
+            case 'mail':
+                return p.subject || p.class;
+            case 'notification':
+                return p.class;
+            case 'cache-event':
+                return `${p.type || 'cache'} ${p.key || ''}`.trim();
+            default:
+                return p.message || 'Event';
+        }
+    };
 
     const isRequest = record.type === 'request';
     const isJob = ['job-attempt', 'queued-job'].includes(record.type);
@@ -276,7 +304,7 @@ export default function RecordShow({
                                     <span>
                                         Events{' '}
                                         <span className="ml-1 text-foreground">
-                                            {queries.length + logs.length}
+                                            {totalEvents}
                                         </span>
                                     </span>
                                     <span>
@@ -361,6 +389,71 @@ export default function RecordShow({
                     )}
                 </Card>
 
+                {/* Request Payload Card */}
+                {(() => {
+                    let body = payload.payload;
+
+                    if (typeof body === 'string') {
+                        try {
+                            body = JSON.parse(body);
+                        } catch {
+                            // Leave non-JSON bodies as their raw string.
+                        }
+                    }
+
+                    const isEmpty =
+                        body === null ||
+                        body === undefined ||
+                        body === '' ||
+                        (typeof body === 'object' &&
+                            Object.keys(body).length === 0);
+
+                    if (isEmpty) {
+                        return null;
+                    }
+
+                    return (
+                        <Card className="border-border bg-card shadow-2xl">
+                            <div
+                                className="flex cursor-pointer items-center justify-between p-4 transition-colors hover:bg-muted/30"
+                                onClick={() =>
+                                    setExpandedPayload(!expandedPayload)
+                                }
+                            >
+                                <h3 className="text-xs font-bold text-foreground uppercase">
+                                    Request Payload
+                                </h3>
+                                <div className="flex h-5 w-5 items-center justify-center rounded bg-muted">
+                                    {expandedPayload ? (
+                                        <ChevronDown className="h-3 w-3" />
+                                    ) : (
+                                        <ChevronRight className="h-3 w-3" />
+                                    )}
+                                </div>
+                            </div>
+                            {expandedPayload && (
+                                <div className="border-t border-border p-6 text-xs">
+                                    <SyntaxHighlighter
+                                        language="json"
+                                        style={vscDarkPlus}
+                                        customStyle={{
+                                            margin: 0,
+                                            borderRadius: '0.5rem',
+                                            border: '1px solid hsl(var(--border))',
+                                        }}
+                                        wrapLines={true}
+                                        wrapLongLines={true}
+                                    >
+                                        {typeof body === 'string'
+                                            ? body
+                                            : JSON.stringify(body, null, 4)}
+                                    </SyntaxHighlighter>
+                                </div>
+                            )}
+                        </Card>
+                    );
+                })()}
+
                 {/* Timeline Card */}
                 <Card className="border-border bg-card p-8 shadow-2xl">
                     <div className="mb-8 flex items-center justify-between">
@@ -442,11 +535,7 @@ export default function RecordShow({
                                                         {sub.type}
                                                     </span>
                                                     <span className="line-clamp-1 max-w-[400px] font-mono text-[10px] text-muted-foreground">
-                                                        {sub.type === 'query'
-                                                            ? sub.payload.sql
-                                                            : sub.payload
-                                                                  .message ||
-                                                              'Log event'}
+                                                        {subLabel(sub)}
                                                     </span>
                                                 </div>
                                                 <div

--- a/resources/js/pages/projects/requests/index.tsx
+++ b/resources/js/pages/projects/requests/index.tsx
@@ -1,4 +1,4 @@
-import { Head, Link, usePage, router } from '@inertiajs/react';
+﻿import { Head, Link, usePage, router } from '@inertiajs/react';
 import {
     Activity,
     AlertCircle,
@@ -8,7 +8,6 @@ import {
     ChevronsUpDown,
     Globe,
 } from 'lucide-react';
-import { useEffect } from 'react';
 import {
     BarChart,
     Bar,
@@ -29,6 +28,7 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
+import { useLiveReload } from '@/hooks/use-live-reload';
 import AppLayout from '@/layouts/app-layout';
 import { monitoringQuery } from '@/lib/monitoring-query';
 import { formatMicroSeconds, formatCompactNumber } from '@/lib/utils';
@@ -61,21 +61,7 @@ export default function RequestsIndex({
     const projectSlug =
         props.current_project?.slug || props.currentProject?.slug;
 
-    useEffect(() => {
-        if (!currentProject?.id || !window.Echo) {
-            return;
-        }
-
-        const channel = window.Echo.private(
-            `project.${currentProject.id}`,
-        ).listen('.ProjectDataIngested', () => {
-            router.reload({ preserveScroll: true, preserveState: true } as any);
-        });
-
-        return () => {
-            channel.stopListening('.ProjectDataIngested');
-        };
-    }, [currentProject?.id]);
+    useLiveReload(currentProject?.id);
 
     const data = requests.data || [];
     const requestDetailsHref = (hash: string | number) =>

--- a/resources/js/pages/projects/requests/show.tsx
+++ b/resources/js/pages/projects/requests/show.tsx
@@ -1,5 +1,6 @@
-import { Head, Link, usePage } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { Search, Globe, ArrowUpRight } from 'lucide-react';
+import { Pagination } from '@/components/pagination';
 import { Badge } from '@/components/ui/badge';
 import {
     Table,
@@ -160,6 +161,7 @@ export default function RequestDetails({
                                 ))}
                             </TableBody>
                         </Table>
+                        <Pagination links={records.links} meta={records} />
                     </div>
                 </div>
             </div>

--- a/resources/js/pages/projects/scheduled-tasks/index.tsx
+++ b/resources/js/pages/projects/scheduled-tasks/index.tsx
@@ -1,7 +1,6 @@
-import { Head, Link, usePage, router } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { formatDistanceToNow } from 'date-fns';
 import { Calendar, ArrowUpRight, Terminal, Timer } from 'lucide-react';
-import { useEffect } from 'react';
 import {
     BarChart,
     Bar,
@@ -23,6 +22,7 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
+import { useLiveReload } from '@/hooks/use-live-reload';
 import AppLayout from '@/layouts/app-layout';
 import { monitoringQuery } from '@/lib/monitoring-query';
 import { formatMicroSeconds, formatCompactNumber } from '@/lib/utils';
@@ -49,21 +49,7 @@ export default function ScheduledTasksIndex({
     const projectSlug =
         props.current_project?.slug || props.currentProject?.slug;
 
-    useEffect(() => {
-        if (!currentProject?.id || !window.Echo) {
-            return;
-        }
-
-        const channel = window.Echo.private(
-            `project.${currentProject.id}`,
-        ).listen('.ProjectDataIngested', () => {
-            router.reload({ preserveScroll: true, preserveState: true } as any);
-        });
-
-        return () => {
-            channel.stopListening('.ProjectDataIngested');
-        };
-    }, [currentProject?.id]);
+    useLiveReload(currentProject?.id);
 
     const data = tasks.data || [];
     const scheduledTaskDetailsHref = (hash: string | number) =>

--- a/resources/js/pages/projects/scheduled-tasks/show.tsx
+++ b/resources/js/pages/projects/scheduled-tasks/show.tsx
@@ -1,5 +1,6 @@
-import { Head, Link, usePage } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { Search, Clock, Activity, ArrowUpRight } from 'lucide-react';
+import { Pagination } from '@/components/pagination';
 import { Badge } from '@/components/ui/badge';
 import {
     Table,
@@ -139,6 +140,7 @@ export default function ScheduledTaskDetails({
                                 ))}
                             </TableBody>
                         </Table>
+                        <Pagination links={records.links} meta={records} />
                     </div>
                 </div>
             </div>

--- a/resources/js/pages/projects/security/index.tsx
+++ b/resources/js/pages/projects/security/index.tsx
@@ -1,4 +1,4 @@
-import { Head, usePage, router } from '@inertiajs/react';
+﻿import { Head, usePage } from '@inertiajs/react';
 import {
     Shield,
     AlertTriangle,
@@ -7,10 +7,10 @@ import {
     Lock,
     ShieldAlert,
 } from 'lucide-react';
-import { useEffect } from 'react';
 import { IssueTable } from '@/components/issue-table';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useLiveReload } from '@/hooks/use-live-reload';
 import AppLayout from '@/layouts/app-layout';
 
 interface SecurityProps {
@@ -32,21 +32,7 @@ export default function SecurityIndex({
     const { props }: any = usePage();
     const currentProject = props.current_project || props.currentProject;
 
-    useEffect(() => {
-        if (!currentProject?.id || !window.Echo) {
-            return;
-        }
-
-        const channel = window.Echo.private(
-            `project.${currentProject.id}`,
-        ).listen('.ProjectDataIngested', () => {
-            router.reload({ preserveScroll: true, preserveState: true } as any);
-        });
-
-        return () => {
-            channel.stopListening('.ProjectDataIngested');
-        };
-    }, [currentProject?.id]);
+    useLiveReload(currentProject?.id);
 
     return (
         <div className="animate-in space-y-12 duration-700 fade-in slide-in-from-bottom-4">

--- a/resources/js/pages/projects/security/show.tsx
+++ b/resources/js/pages/projects/security/show.tsx
@@ -1,4 +1,4 @@
-import { Head, Link, usePage } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import {
     Shield,
     ArrowUpRight,
@@ -6,6 +6,7 @@ import {
     Clock,
     Globe,
 } from 'lucide-react';
+import { Pagination } from '@/components/pagination';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import {
@@ -75,7 +76,7 @@ export default function SecurityDetails({
                                         meta.last_seen_at,
                                     ).toLocaleString()}
                                 </span>
-                                <span>•</span>
+                                <span>â€¢</span>
                                 <span className="flex items-center gap-1 font-mono tracking-normal lowercase">
                                     {hash}
                                 </span>
@@ -203,7 +204,7 @@ export default function SecurityDetails({
                                                                     {t.type}{' '}
                                                                     {t.detail
                                                                         ? `(${t.detail})`
-                                                                        : `→ ${t.source}`}
+                                                                        : `â†’ ${t.source}`}
                                                                 </Badge>
                                                             ),
                                                         )}
@@ -352,6 +353,7 @@ export default function SecurityDetails({
                                 ))}
                             </TableBody>
                         </Table>
+                        <Pagination links={records.links} meta={records} />
                     </Card>
                 </section>
             </div>

--- a/resources/js/pages/projects/uptime/index.tsx
+++ b/resources/js/pages/projects/uptime/index.tsx
@@ -1,4 +1,4 @@
-import { Head, usePage, router } from '@inertiajs/react';
+﻿import { Head, usePage } from '@inertiajs/react';
 import {
     Activity as ActivityIcon,
     Clock,
@@ -8,31 +8,17 @@ import {
     History,
     RefreshCw,
 } from 'lucide-react';
-import { useEffect } from 'react';
 import { AreaChart, Area, Tooltip, ResponsiveContainer } from 'recharts';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
+import { useLiveReload } from '@/hooks/use-live-reload';
 import AppLayout from '@/layouts/app-layout';
 
 export default function UptimeIndex({ checks, uptime_stats, period }: any) {
     const { props }: any = usePage();
     const currentProject = props.current_project || props.currentProject;
 
-    useEffect(() => {
-        if (!currentProject?.id || !window.Echo) {
-            return;
-        }
-
-        const channel = window.Echo.private(
-            `project.${currentProject.id}`,
-        ).listen('.ProjectDataIngested', () => {
-            router.reload({ preserveScroll: true, preserveState: true } as any);
-        });
-
-        return () => {
-            channel.stopListening('.ProjectDataIngested');
-        };
-    }, [currentProject?.id]);
+    useLiveReload(currentProject?.id);
 
     return (
         <>

--- a/resources/js/pages/projects/users/index.tsx
+++ b/resources/js/pages/projects/users/index.tsx
@@ -1,6 +1,5 @@
-import { Head, Link, usePage, router } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { ArrowUpRight, AlertCircle, Users } from 'lucide-react';
-import { useEffect } from 'react';
 import { BarChart, Bar, ResponsiveContainer, Tooltip, XAxis } from 'recharts';
 import { EmptyState } from '@/components/empty-state';
 import { Pagination } from '@/components/pagination';
@@ -13,6 +12,7 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
+import { useLiveReload } from '@/hooks/use-live-reload';
 import AppLayout from '@/layouts/app-layout';
 import { monitoringQuery } from '@/lib/monitoring-query';
 import { formatCompactNumber } from '@/lib/utils';
@@ -40,21 +40,7 @@ export default function UsersIndex({
     const projectSlug =
         props.current_project?.slug || props.currentProject?.slug;
 
-    useEffect(() => {
-        if (!currentProject?.id || !window.Echo) {
-            return;
-        }
-
-        const channel = window.Echo.private(
-            `project.${currentProject.id}`,
-        ).listen('.ProjectDataIngested', () => {
-            router.reload({ preserveScroll: true, preserveState: true } as any);
-        });
-
-        return () => {
-            channel.stopListening('.ProjectDataIngested');
-        };
-    }, [currentProject?.id]);
+    useLiveReload(currentProject?.id);
 
     const data = users.data || [];
     const userDetailsHref = (hash: string | number) =>

--- a/resources/js/pages/projects/users/show.tsx
+++ b/resources/js/pages/projects/users/show.tsx
@@ -1,5 +1,6 @@
-import { Head, Link, usePage } from '@inertiajs/react';
+﻿import { Head, Link, usePage } from '@inertiajs/react';
 import { User, Search, ArrowUpRight, Activity } from 'lucide-react';
+import { Pagination } from '@/components/pagination';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import {
@@ -266,6 +267,7 @@ export default function UserShow({
                                 ))}
                             </TableBody>
                         </Table>
+                        <Pagination links={records.links} meta={records} />
                     </div>
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,6 +41,7 @@ require __DIR__.'/settings.php';
 
 Route::prefix('{current_team}/{project}')
     ->middleware(['auth', 'verified', EnsureTeamMembership::class, EnsureProjectExists::class])
+    ->scopeBindings()
     ->group(function () {
         Route::get('dashboard', [RecordController::class, 'index'])->name('dashboard');
 

--- a/tests/Feature/LogSearchTest.php
+++ b/tests/Feature/LogSearchTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Models\Project;
+use App\Models\Record;
+use App\Services\IngestService;
+use App\Services\RecordService;
+
+function ingestLogs(Project $project, array $records): void
+{
+    app(IngestService::class)->ingest($project, $records);
+}
+
+function logResults(Project $project, ?string $search): array
+{
+    return collect(app(RecordService::class)->getLogRecords($project, $search, '24h')->items())
+        ->map(fn ($r) => $r->payload['message'] ?? null)
+        ->all();
+}
+
+test('a log stores its level and message in the searchable column', function () {
+    $project = Project::factory()->create();
+
+    ingestLogs($project, [
+        ['t' => 'log', 'level' => 'error', 'message' => 'Database connection timed out'],
+    ]);
+
+    $record = Record::where('project_id', $project->id)->where('type', 'log')->first();
+
+    // The level is folded in so searching a level still finds the entry.
+    expect($record->message)->toBe('error Database connection timed out');
+});
+
+test('log search matches words in the message', function () {
+    $project = Project::factory()->create();
+
+    ingestLogs($project, [
+        ['t' => 'log', 'level' => 'error', 'message' => 'Database connection timed out'],
+        ['t' => 'log', 'level' => 'info', 'message' => 'User signed in'],
+        ['t' => 'log', 'level' => 'warning', 'message' => 'Cache miss for homepage'],
+    ]);
+
+    expect(logResults($project, 'Database'))->toBe(['Database connection timed out'])
+        ->and(logResults($project, 'homepage'))->toBe(['Cache miss for homepage']);
+});
+
+test('log search matches the level as a term', function () {
+    $project = Project::factory()->create();
+
+    ingestLogs($project, [
+        ['t' => 'log', 'level' => 'error', 'message' => 'Payment failed'],
+        ['t' => 'log', 'level' => 'error', 'message' => 'Timeout reached'],
+        ['t' => 'log', 'level' => 'info', 'message' => 'All good'],
+    ]);
+
+    expect(logResults($project, 'error'))->toHaveCount(2)
+        ->and(logResults($project, 'info'))->toBe(['All good']);
+});
+
+test('a search that matches nothing returns an empty page', function () {
+    $project = Project::factory()->create();
+
+    ingestLogs($project, [
+        ['t' => 'log', 'level' => 'info', 'message' => 'Nothing to see'],
+    ]);
+
+    $paginator = app(RecordService::class)->getLogRecords($project, 'nonexistentterm', '24h');
+
+    expect($paginator->total())->toBe(0);
+});
+
+test('log search no longer scans the JSON payload column', function () {
+    $project = Project::factory()->create();
+    ingestLogs($project, [['t' => 'log', 'level' => 'info', 'message' => 'hello world']]);
+
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+    app(RecordService::class)->getLogRecords($project, 'hello', '24h');
+    $queries = collect(DB::getQueryLog())->pluck('query')->implode(' ');
+    DB::disableQueryLog();
+
+    // The search targets the narrow message column, not the fat payload JSON.
+    expect($queries)->not->toContain('`payload` like')
+        ->and($queries)->toContain('message');
+});
+
+test('the backfill lifts the message out of legacy log payloads', function () {
+    $project = Project::factory()->create();
+
+    Record::create([
+        'project_id' => $project->id,
+        'type' => 'log',
+        'fingerprint' => null,
+        'payload' => ['level' => 'warning', 'message' => 'legacy disk warning'],
+        'created_at' => now(),
+    ]);
+
+    expect(Record::where('project_id', $project->id)->value('message'))->toBeNull();
+
+    $this->artisan('laraowl:rollups:backfill')->assertExitCode(0);
+
+    expect(Record::where('project_id', $project->id)->value('message'))->toBe('warning legacy disk warning')
+        ->and(logResults($project, 'disk'))->toBe(['legacy disk warning']);
+});

--- a/tests/Feature/RecordLookupOptimisationTest.php
+++ b/tests/Feature/RecordLookupOptimisationTest.php
@@ -1,0 +1,235 @@
+<?php
+
+use App\Models\Project;
+use App\Models\Record;
+use App\Models\RecordIpBucket;
+use App\Models\Threshold;
+use App\Services\IngestService;
+use App\Services\RecordService;
+use Illuminate\Support\Facades\DB;
+
+function ingestLookup(Project $project, array $records): void
+{
+    app(IngestService::class)->ingest($project, $records);
+}
+
+test('the user and ip are lifted into indexed columns at ingest', function () {
+    $project = Project::factory()->create();
+
+    ingestLookup($project, [
+        ['t' => 'request', 'status_code' => 200, 'user' => '42', 'ip' => '10.0.0.1'],
+        ['t' => 'request', 'status_code' => 200, 'user' => 'guest_abc', 'ip' => '10.0.0.2'],
+        ['t' => 'request', 'status_code' => 200],
+        ['t' => 'exception', 'class' => 'E', 'message' => 'm', 'user' => ['id' => 7, 'name' => 'Ada']],
+    ]);
+
+    $records = Record::where('project_id', $project->id)->orderBy('id')->get();
+
+    // Guests get a user_key too: a user's history is every record they produced.
+    expect($records[0]->user_key)->toBe('42')
+        ->and($records[0]->ip)->toBe('10.0.0.1')
+        ->and($records[1]->user_key)->toBe('guest_abc')
+        ->and($records[2]->user_key)->toBeNull()
+        ->and($records[2]->ip)->toBeNull()
+        ->and($records[3]->user_key)->toBe('7');
+});
+
+test('user history resolves the md5 hash and reads the indexed column', function () {
+    $project = Project::factory()->create();
+
+    ingestLookup($project, [
+        ['t' => 'request', '_group' => 'a', 'status_code' => 200, 'user' => '42'],
+        ['t' => 'request', '_group' => 'a', 'status_code' => 500, 'user' => '42'],
+        ['t' => 'request', '_group' => 'a', 'status_code' => 200, 'user' => '99'],
+    ]);
+
+    $history = app(RecordService::class)->getUserHistory($project, md5('42'), '24h');
+
+    expect($history['records']->total())->toBe(2)
+        ->and((string) $history['user_id'])->toBe('42')
+        ->and((int) $history['stats']->total)->toBe(2);
+
+    // The old query filtered on MD5(JSON_EXTRACT(...)), which no index could serve.
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+    app(RecordService::class)->getUserHistory($project, md5('42'), '24h');
+    $queries = collect(DB::getQueryLog())->pluck('query')->implode(' ');
+    DB::disableQueryLog();
+
+    expect($queries)->not->toContain("JSON_EXTRACT(payload, '$.user')");
+});
+
+test('an unknown user hash yields an empty history rather than everything', function () {
+    $project = Project::factory()->create();
+
+    ingestLookup($project, [['t' => 'request', 'status_code' => 200, 'user' => '42']]);
+
+    $history = app(RecordService::class)->getUserHistory($project, md5('does-not-exist'), '24h');
+
+    expect($history['records']->total())->toBe(0);
+});
+
+test('the raw record list total matches an honest count exactly', function () {
+    $project = Project::factory()->create();
+
+    $batch = [];
+    for ($i = 0; $i < 7; $i++) {
+        $batch[] = ['t' => 'log', 'level' => 'info', 'message' => "line {$i}"];
+    }
+    ingestLookup($project, $batch);
+
+    $paginator = app(RecordService::class)->getLogRecords($project, null, '24h');
+
+    $rawCount = Record::where('project_id', $project->id)->ofType('log')->forPeriod('24h')->count();
+
+    // The total now comes from the rollups, so it must agree to the record.
+    expect($paginator->total())->toBe(7)
+        ->and($paginator->total())->toBe($rawCount);
+});
+
+test('a searched record list keeps counting for real', function () {
+    $project = Project::factory()->create();
+
+    ingestLookup($project, [
+        ['t' => 'log', 'level' => 'info', 'message' => 'needle here'],
+        ['t' => 'log', 'level' => 'info', 'message' => 'nothing'],
+    ]);
+
+    // A search changes what is being counted, so the rollup total cannot be used.
+    expect(app(RecordService::class)->getLogRecords($project, 'needle', '24h')->total())->toBe(1);
+});
+
+test('the paginator no longer counts raw records', function () {
+    $project = Project::factory()->create();
+    ingestLookup($project, [['t' => 'log', 'level' => 'info', 'message' => 'x']]);
+
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+    app(RecordService::class)->getPaginatedRecords($project, 'log', null, '24h');
+    $queries = collect(DB::getQueryLog())->pluck('query');
+    DB::disableQueryLog();
+
+    $countsRecords = $queries->contains(fn (string $sql) => str_contains($sql, 'count(*)') && str_contains($sql, '"records"'));
+
+    expect($countsRecords)->toBeFalse();
+});
+
+test('distinct counts come from the group rollups', function () {
+    $project = Project::factory()->create();
+
+    ingestLookup($project, [
+        ['t' => 'exception', '_group' => 'a', 'class' => 'A', 'message' => 'm'],
+        ['t' => 'exception', '_group' => 'a', 'class' => 'A', 'message' => 'm'],
+        ['t' => 'exception', '_group' => 'b', 'class' => 'B', 'message' => 'm'],
+        ['t' => 'mail', '_group' => 'm1', 'class' => 'Welcome', 'mailer' => 'smtp'],
+        ['t' => 'notification', '_group' => 'n1', 'class' => 'Shipped', 'channel' => 'mail'],
+        ['t' => 'notification', '_group' => 'n2', 'class' => 'Shipped', 'channel' => 'slack'],
+    ]);
+
+    $records = app(RecordService::class);
+
+    expect($records->getExceptionStats($project, '24h')['overview']['unique'])->toBe(2)
+        ->and($records->getMailStats($project, '24h')['overview']['unique'])->toBe(1)
+        ->and($records->getNotificationStats($project, '24h')['overview']['channels'])->toBe(2);
+});
+
+test('the security page counts distinct ips from the hourly ip buckets', function () {
+    $project = Project::factory()->create();
+
+    ingestLookup($project, [
+        ['t' => 'request', 'status_code' => 200, 'ip' => '1.1.1.1'],
+        ['t' => 'request', 'status_code' => 200, 'ip' => '1.1.1.1'],
+        ['t' => 'request', 'status_code' => 200, 'ip' => '2.2.2.2'],
+    ]);
+
+    $overview = app(RecordService::class)->getSecurityStats($project, '24h')['overview'];
+
+    expect($overview['unique_ips'])->toBe(2)
+        ->and($overview['total_scanned'])->toBe(3)
+        // Two ips, one hour, and the repeat is counted not duplicated.
+        ->and(RecordIpBucket::where('project_id', $project->id)->count())->toBe(2)
+        ->and((int) RecordIpBucket::where('ip', '1.1.1.1')->value('count'))->toBe(2);
+});
+
+test('a distinct ip seen across two hours is counted once', function () {
+    $project = Project::factory()->create();
+
+    $this->travelTo(now()->subHours(3)->startOfHour());
+    ingestLookup($project, [['t' => 'request', 'status_code' => 200, 'ip' => '5.5.5.5']]);
+
+    $this->travelTo(now()->addHours(2));
+    ingestLookup($project, [['t' => 'request', 'status_code' => 200, 'ip' => '5.5.5.5']]);
+
+    $this->travelBack();
+
+    expect(RecordIpBucket::where('project_id', $project->id)->count())->toBe(2)
+        ->and(app(RecordService::class)->getSecurityStats($project, '24h')['overview']['unique_ips'])->toBe(1);
+});
+
+test('thresholds are loaded once per batch, not once per record', function () {
+    $project = Project::factory()->create();
+
+    Threshold::create([
+        'project_id' => $project->id,
+        'type' => 'route',
+        'key' => '/slow',
+        'value' => 1_000_000,
+        'is_enabled' => true,
+    ]);
+
+    $batch = [];
+    for ($i = 0; $i < 25; $i++) {
+        $batch[] = ['t' => 'request', 'route_path' => '/slow', 'status_code' => 200, 'duration' => 10];
+    }
+
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+    ingestLookup($project, $batch);
+    $thresholdQueries = collect(DB::getQueryLog())
+        ->filter(fn (array $entry) => str_contains($entry['query'], 'thresholds'))
+        ->count();
+    DB::disableQueryLog();
+
+    expect($thresholdQueries)->toBe(1);
+});
+
+test('a threshold added between batches is picked up', function () {
+    $project = Project::factory()->create();
+
+    ingestLookup($project, [['t' => 'request', 'route_path' => '/slow', 'status_code' => 200, 'duration' => 10_000]]);
+
+    Threshold::create([
+        'project_id' => $project->id,
+        'type' => 'route',
+        'key' => '/slow',
+        'value' => 5, // 5ms
+        'is_enabled' => true,
+    ]);
+
+    // The per-batch cache must not outlive the ingest call. Duration in µs, so
+    // 500ms comfortably exceeds the 5ms threshold.
+    ingestLookup($project, [['t' => 'request', 'route_path' => '/slow', 'status_code' => 200, 'duration' => 500_000]]);
+
+    expect($project->issues()->where('title', 'Slow Route: /slow')->exists())->toBeTrue();
+});
+
+test('the backfill lifts user_key and ip out of legacy payloads', function () {
+    $project = Project::factory()->create();
+
+    Record::create([
+        'project_id' => $project->id,
+        'type' => 'request',
+        'fingerprint' => 'f',
+        'payload' => ['status_code' => 200, 'user' => '55', 'ip' => '9.9.9.9'],
+        'created_at' => now(),
+    ]);
+
+    expect(Record::where('project_id', $project->id)->value('user_key'))->toBeNull();
+
+    $this->artisan('laraowl:rollups:backfill')->assertExitCode(0);
+
+    $record = Record::where('project_id', $project->id)->first();
+
+    expect($record->user_key)->toBe('55')
+        ->and($record->ip)->toBe('9.9.9.9');
+});

--- a/tests/Feature/RecordOccurrenceTest.php
+++ b/tests/Feature/RecordOccurrenceTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Models\Project;
+use App\Models\Record;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\IngestService;
+
+/**
+ * Log in a user who belongs to the project's team, and return both.
+ */
+function actingMember(): array
+{
+    $team = Team::factory()->create();
+    $user = User::factory()->create();
+    $team->members()->attach($user, ['role' => TeamRole::Owner->value]);
+    $project = Project::factory()->create(['team_id' => $team->id]);
+
+    return [$user, $team, $project];
+}
+
+test('the trace id is lifted into an indexed column at ingest', function () {
+    [, , $project] = actingMember();
+
+    app(IngestService::class)->ingest($project, [
+        ['t' => 'request', 'status_code' => 200, 'trace_id' => 'abc-123'],
+        ['t' => 'query', 'sql' => 'select 1', 'duration' => 10, 'trace_id' => 'abc-123'],
+        ['t' => 'log', 'level' => 'info', 'message' => 'hi'],
+    ]);
+
+    $request = Record::where('project_id', $project->id)->where('type', 'request')->first();
+    $query = Record::where('project_id', $project->id)->where('type', 'query')->first();
+    $log = Record::where('project_id', $project->id)->where('type', 'log')->first();
+
+    expect($request->trace_id)->toBe('abc-123')
+        ->and($query->trace_id)->toBe('abc-123')
+        ->and($log->trace_id)->toBeNull();
+});
+
+test('the occurrence page loads the queries and events sharing the trace', function () {
+    [$user, $team, $project] = actingMember();
+
+    app(IngestService::class)->ingest($project, [
+        ['t' => 'request', 'status_code' => 200, 'route_path' => '/checkout', 'queries' => 2, 'trace_id' => 't-1'],
+        ['t' => 'query', 'sql' => 'select * from carts', 'duration' => 1200, 'trace_id' => 't-1'],
+        ['t' => 'query', 'sql' => 'update carts set total = ?', 'duration' => 800, 'trace_id' => 't-1'],
+        // A different request's query must not leak into this trace.
+        ['t' => 'query', 'sql' => 'select 999', 'duration' => 5, 'trace_id' => 't-2'],
+    ]);
+
+    $request = Record::where('project_id', $project->id)->where('type', 'request')->first();
+
+    $this->actingAs($user)
+        ->get(route('records.show', [
+            'current_team' => $team->slug,
+            'project' => $project->slug,
+            'record' => $request->id,
+        ]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('projects/records/show')
+            ->where('record.id', $request->id)
+            ->has('relatedRecords', 2)
+            ->where('relatedRecords.0.payload.sql', 'select * from carts')
+            ->where('relatedRecords.1.payload.sql', 'update carts set total = ?')
+        );
+});
+
+test('a request with no trace exposes no related records', function () {
+    [$user, $team, $project] = actingMember();
+
+    app(IngestService::class)->ingest($project, [
+        ['t' => 'request', 'status_code' => 200, 'route_path' => '/'],
+    ]);
+
+    $request = Record::where('project_id', $project->id)->first();
+
+    $this->actingAs($user)
+        ->get(route('records.show', [
+            'current_team' => $team->slug,
+            'project' => $project->slug,
+            'record' => $request->id,
+        ]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page->has('relatedRecords', 0));
+});
+
+test('a member cannot open a record belonging to another teams project', function () {
+    [$attacker, $attackerTeam, $attackerProject] = actingMember();
+
+    // A different tenant's project with a record the attacker must never see.
+    [, , $victimProject] = actingMember();
+    app(IngestService::class)->ingest($victimProject, [
+        ['t' => 'request', 'status_code' => 200, 'route_path' => '/secret', 'ip' => '10.9.9.9'],
+    ]);
+    $victimRecord = Record::where('project_id', $victimProject->id)->firstOrFail();
+
+    // The attacker points their own project's route at the victim's record id.
+    $this->actingAs($attacker)
+        ->get(route('records.show', [
+            'current_team' => $attackerTeam->slug,
+            'project' => $attackerProject->slug,
+            'record' => $victimRecord->id,
+        ]))
+        ->assertNotFound();
+});
+
+test('the backfill lifts trace_id out of legacy payloads', function () {
+    [, , $project] = actingMember();
+
+    Record::create([
+        'project_id' => $project->id,
+        'type' => 'request',
+        'fingerprint' => 'f',
+        'payload' => ['status_code' => 200, 'trace_id' => 'legacy-trace'],
+        'created_at' => now(),
+    ]);
+
+    expect(Record::where('project_id', $project->id)->value('trace_id'))->toBeNull();
+
+    $this->artisan('laraowl:rollups:backfill')->assertExitCode(0);
+
+    expect(Record::where('project_id', $project->id)->value('trace_id'))->toBe('legacy-trace');
+});

--- a/tests/Feature/RecordPeriodTest.php
+++ b/tests/Feature/RecordPeriodTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Models\Project;
+use App\Models\Record;
+
+function seedRecordAgedDays(Project $project, int $days): void
+{
+    Record::create([
+        'project_id' => $project->id,
+        'type' => 'request',
+        'fingerprint' => 'f',
+        'payload' => ['status_code' => 200],
+        'created_at' => now()->subDays($days),
+    ]);
+}
+
+test('an unrecognised period falls back to a bounded window instead of scanning everything', function (?string $period) {
+    $project = Project::factory()->create();
+    seedRecordAgedDays($project, 3);
+
+    // This used to return the query unfiltered, turning every such call into a
+    // full table scan and reporting records from outside the requested window.
+    expect(Record::query()->forPeriod($period)->count())->toBe(0);
+})->with([null, '', 'bogus', 'all', '24h']);
+
+test('known periods keep their windows', function () {
+    $project = Project::factory()->create();
+    seedRecordAgedDays($project, 3);
+
+    expect(Record::query()->forPeriod('1h')->count())->toBe(0)
+        ->and(Record::query()->forPeriod('7d')->count())->toBe(1)
+        ->and(Record::query()->forPeriod('30d')->count())->toBe(1);
+});
+
+test('a custom period uses the supplied bounds', function () {
+    $project = Project::factory()->create();
+    seedRecordAgedDays($project, 3);
+
+    $from = now()->subDays(4)->toDateTimeString();
+    $to = now()->subDays(2)->toDateTimeString();
+
+    expect(Record::query()->forPeriod('custom', $from, $to)->count())->toBe(1)
+        ->and(Record::query()->forPeriod('custom', now()->subDay()->toDateTimeString(), now()->toDateTimeString())->count())->toBe(0);
+});
+
+test('every period still applies a created_at bound', function (?string $period) {
+    $sql = Record::query()->forPeriod($period)->toSql();
+
+    expect($sql)->toContain('created_at');
+})->with([null, 'bogus', '1h', '24h', '7d', '14d', '30d']);

--- a/tests/Feature/RecordServiceTest.php
+++ b/tests/Feature/RecordServiceTest.php
@@ -1,34 +1,30 @@
 <?php
 
 use App\Models\Project;
-use App\Models\Record;
+use App\Services\IngestService;
 use App\Services\RecordService;
 
 it('handles non numeric outgoing request status values without SQL errors', function () {
     $project = Project::factory()->create();
 
-    Record::create([
-        'project_id' => $project->id,
-        'type' => 'outgoing-request',
-        'fingerprint' => 'failed-status',
-        'payload' => [
+    // Ingested rather than inserted directly, so the rollups the overview now
+    // reads from are written. The client always sends `_group`, which becomes
+    // the fingerprint the host list groups on.
+    app(IngestService::class)->ingest($project, [
+        [
+            't' => 'outgoing-request',
+            '_group' => 'failed-status',
             'host' => 'api.example.com',
             'status' => 'failed',
             'duration' => 125,
         ],
-        'created_at' => now(),
-    ]);
-
-    Record::create([
-        'project_id' => $project->id,
-        'type' => 'outgoing-request',
-        'fingerprint' => 'ok-status',
-        'payload' => [
+        [
+            't' => 'outgoing-request',
+            '_group' => 'ok-status',
             'host' => 'api.example.com',
             'status_code' => 200,
             'duration' => 75,
         ],
-        'created_at' => now(),
     ]);
 
     $stats = app(RecordService::class)->getOutgoingRequestStats($project, '24h');

--- a/tests/Feature/RollupBackfillTest.php
+++ b/tests/Feature/RollupBackfillTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use App\Models\Project;
+use App\Models\Record;
+use App\Models\RecordRollup;
+use App\Models\RecordUserBucket;
+use App\Services\IngestService;
+
+function rollupSnapshot(Project $project): array
+{
+    return RecordRollup::where('project_id', $project->id)
+        ->orderBy('type')
+        ->orderBy('bucket')
+        ->get()
+        ->map(fn (RecordRollup $rollup) => collect($rollup->getAttributes())->except('id')->all())
+        ->all();
+}
+
+test('a backfill rebuilds exactly what live ingestion would have written', function () {
+    $project = Project::factory()->create();
+
+    app(IngestService::class)->ingest($project, [
+        ['t' => 'request', 'status_code' => 200, 'duration' => 10, 'user' => '1'],
+        ['t' => 'request', 'status_code' => 500, 'duration' => 3000, 'user' => '2'],
+        ['t' => 'exception', 'class' => 'E', 'message' => 'm', 'user' => '1'],
+        ['t' => 'cache-event', 'key' => 'k', 'type' => 'hit'],
+    ]);
+
+    $live = rollupSnapshot($project);
+    $liveUsers = RecordUserBucket::where('project_id', $project->id)->count();
+
+    // Throw the rollups away, leaving only the raw records behind.
+    RecordRollup::where('project_id', $project->id)->delete();
+    RecordUserBucket::where('project_id', $project->id)->delete();
+
+    $this->artisan('laraowl:rollups:backfill')->assertExitCode(0);
+
+    expect(rollupSnapshot($project))->toEqual($live)
+        ->and(RecordUserBucket::where('project_id', $project->id)->count())->toBe($liveUsers);
+});
+
+test('running the backfill twice does not double count', function () {
+    $project = Project::factory()->create();
+
+    app(IngestService::class)->ingest($project, [
+        ['t' => 'request', 'status_code' => 200, 'duration' => 10, 'user' => '1'],
+        ['t' => 'request', 'status_code' => 200, 'duration' => 10, 'user' => '1'],
+    ]);
+
+    $this->artisan('laraowl:rollups:backfill')->assertExitCode(0);
+    $once = rollupSnapshot($project);
+
+    $this->artisan('laraowl:rollups:backfill')->assertExitCode(0);
+
+    // The live path increments, so a replay that did not clear first would
+    // silently accumulate on every run.
+    expect(rollupSnapshot($project))->toEqual($once);
+
+    $rollup = RecordRollup::where('project_id', $project->id)->first();
+    expect($rollup->count)->toBe(2);
+});
+
+test('the backfill can be limited to one project', function () {
+    $mine = Project::factory()->create();
+    $theirs = Project::factory()->create();
+
+    foreach ([$mine, $theirs] as $project) {
+        app(IngestService::class)->ingest($project, [['t' => 'request', 'status_code' => 200]]);
+    }
+
+    RecordRollup::query()->delete();
+
+    $this->artisan('laraowl:rollups:backfill', ['--project' => $mine->slug])->assertExitCode(0);
+
+    expect(RecordRollup::where('project_id', $mine->id)->exists())->toBeTrue()
+        ->and(RecordRollup::where('project_id', $theirs->id)->exists())->toBeFalse();
+});
+
+test('--missing rebuilds only projects whose rollups are empty', function () {
+    $upgraded = Project::factory()->create();
+    $healthy = Project::factory()->create();
+
+    foreach ([$upgraded, $healthy] as $project) {
+        app(IngestService::class)->ingest($project, [['t' => 'request', 'status_code' => 200]]);
+    }
+
+    // Simulate the upgrade: raw records survive, the new tables start empty.
+    RecordRollup::where('project_id', $upgraded->id)->delete();
+
+    $this->artisan('laraowl:rollups:backfill', ['--missing' => true])->assertExitCode(0);
+
+    expect(RecordRollup::where('project_id', $upgraded->id)->exists())->toBeTrue();
+
+    // The healthy project was not touched, so its counters cannot have doubled.
+    expect((int) RecordRollup::where('project_id', $healthy->id)->first()->count)->toBe(1);
+});
+
+test('--missing is a no-op once every project has rollups', function () {
+    $project = Project::factory()->create();
+    app(IngestService::class)->ingest($project, [['t' => 'request', 'status_code' => 200]]);
+
+    $this->artisan('laraowl:rollups:backfill', ['--missing' => true])
+        ->expectsOutputToContain('Every project already has rollups')
+        ->assertExitCode(0);
+
+    expect((int) RecordRollup::where('project_id', $project->id)->first()->count)->toBe(1);
+});
+
+test('a project with no records in range is skipped cleanly', function () {
+    Project::factory()->create();
+
+    $this->artisan('laraowl:rollups:backfill')
+        ->expectsOutputToContain('no records in range')
+        ->assertExitCode(0);
+
+    expect(RecordRollup::count())->toBe(0);
+});
+
+test('the backfill buckets a record by the minute it was created', function () {
+    $project = Project::factory()->create();
+
+    $createdAt = now()->subMinutes(30)->startOfMinute()->addSeconds(37);
+
+    Record::create([
+        'project_id' => $project->id,
+        'type' => 'request',
+        'fingerprint' => 'f',
+        'payload' => ['status_code' => 200, 'duration' => 5],
+        'created_at' => $createdAt,
+    ]);
+
+    $this->artisan('laraowl:rollups:backfill')->assertExitCode(0);
+
+    $rollup = RecordRollup::where('project_id', $project->id)->first();
+
+    expect($rollup->bucket->format('Y-m-d H:i:s'))
+        ->toBe($createdAt->copy()->startOfMinute()->format('Y-m-d H:i:s'));
+});

--- a/tests/Feature/RollupDashboardTest.php
+++ b/tests/Feature/RollupDashboardTest.php
@@ -1,0 +1,279 @@
+<?php
+
+use App\Models\Project;
+use App\Services\IngestService;
+use App\Services\RecordService;
+
+function ingestBatch(Project $project, array $records): void
+{
+    app(IngestService::class)->ingest($project, $records);
+}
+
+function records(): RecordService
+{
+    return app(RecordService::class);
+}
+
+test('quick stats are counted from the rollups in a single grouped read', function () {
+    $project = Project::factory()->create();
+
+    ingestBatch($project, [
+        ['t' => 'request', 'status_code' => 200],
+        ['t' => 'request', 'status_code' => 200],
+        ['t' => 'exception', 'class' => 'E', 'message' => 'm'],
+        ['t' => 'queued-job', 'name' => 'J'],
+        ['t' => 'job-attempt', 'name' => 'J', 'status' => 'processed'],
+        ['t' => 'log', 'level' => 'info'],
+    ]);
+
+    $stats = records()->getQuickStats($project, '1h');
+
+    expect($stats['requests'])->toBe(2)
+        ->and($stats['exceptions'])->toBe(1)
+        ->and($stats['logs'])->toBe(1)
+        ->and($stats['jobs'])->toBe(2)
+        // The key is naively pluralised as "query" + "s"; the frontend relies
+        // on it, so it stays.
+        ->and($stats['querys'])->toBe(0);
+});
+
+test('dashboard totals and breakdowns come from the rollups', function () {
+    $project = Project::factory()->create();
+
+    ingestBatch($project, [
+        ['t' => 'request', 'status_code' => 200, 'duration' => 10, 'user' => '1'],
+        ['t' => 'request', 'status_code' => 404, 'duration' => 20, 'user' => '2'],
+        ['t' => 'request', 'status_code' => 500, 'duration' => 60],
+        ['t' => 'exception', 'class' => 'E', 'message' => 'm'],
+    ]);
+
+    $stats = records()->getDashboardStats($project, '1h');
+
+    expect($stats['total_requests'])->toBe(3)
+        ->and($stats['request_breakdown'])->toMatchArray([
+            'ok' => 1,
+            'client_error' => 1,
+            'server_error' => 1,
+        ])
+        ->and($stats['duration_stats']['avg'])->toBe(30.0)
+        ->and($stats['duration_stats']['max'])->toBe(60.0)
+        ->and($stats['duration_stats']['min'])->toBe(10.0)
+        ->and($stats['total_exceptions'])->toBe(1)
+        ->and($stats['auth_users_count'])->toBe(2)
+        ->and($stats['guest_users_count'])->toBe(1);
+});
+
+test('a user seen across several hours is counted once over the period', function () {
+    $project = Project::factory()->create();
+
+    $this->travelTo(now()->subHours(5)->startOfHour());
+    ingestBatch($project, [['t' => 'request', 'status_code' => 200, 'user' => '7']]);
+
+    $this->travelTo(now()->addHours(2));
+    ingestBatch($project, [['t' => 'request', 'status_code' => 200, 'user' => '7']]);
+    ingestBatch($project, [['t' => 'request', 'status_code' => 200, 'user' => '8']]);
+
+    $this->travelBack();
+
+    $stats = records()->getDashboardStats($project, '24h');
+
+    // Distinct counts are not additive; summing per-bucket counts would give 3.
+    expect($stats['auth_users_count'])->toBe(2)
+        ->and($stats['total_requests'])->toBe(3)
+        ->and($project->userBuckets()->count())->toBe(3);
+});
+
+test('user buckets are hourly, not minutely', function () {
+    $project = Project::factory()->create();
+
+    $this->travelTo(now()->startOfHour()->addMinutes(5));
+    ingestBatch($project, [['t' => 'request', 'status_code' => 200, 'user' => '7']]);
+
+    $this->travelTo(now()->addMinutes(20));
+    ingestBatch($project, [['t' => 'request', 'status_code' => 200, 'user' => '7']]);
+
+    $this->travelBack();
+
+    // Two different minutes, one hour: a minute-granular table stored 914k rows
+    // for a million records, which was 94% of the dashboard's query time.
+    $buckets = $project->userBuckets()->where('type', 'request')->get();
+
+    expect($buckets)->toHaveCount(1)
+        ->and((int) $buckets->first()->count)->toBe(2)
+        ->and($buckets->first()->bucket->format('i:s'))->toBe('00:00');
+});
+
+test('the same user in one bucket is stored once', function () {
+    $project = Project::factory()->create();
+
+    ingestBatch($project, [
+        ['t' => 'request', 'status_code' => 200, 'user' => '7'],
+        ['t' => 'request', 'status_code' => 200, 'user' => '7'],
+    ]);
+
+    expect($project->userBuckets()->where('type', 'request')->count())->toBe(1);
+});
+
+test('a guest id from the client is not treated as an authenticated user', function () {
+    $project = Project::factory()->create();
+
+    ingestBatch($project, [
+        ['t' => 'request', 'status_code' => 200, 'user' => '42'],
+        ['t' => 'request', 'status_code' => 200, 'user' => 'guest_de7fc5f313ff'],
+        ['t' => 'request', 'status_code' => 200, 'user' => 'guest_de7fc5f313ff'],
+        ['t' => 'request', 'status_code' => 200, 'user' => 'guest_aab3238922bc'],
+    ]);
+
+    $stats = records()->getDashboardStats($project, '1h');
+
+    // The client sends `guest_<hash>` rather than null for anonymous visitors.
+    // Counting those as people made guest_users_count zero and let a handful of
+    // guest hashes fill the top-user panel.
+    expect($stats['auth_users_count'])->toBe(1)
+        ->and($stats['guest_users_count'])->toBe(3)
+        ->and($stats['active_users'])->toHaveCount(1)
+        ->and($stats['active_users']->first()->user_id)->toBe('42')
+        ->and($project->userBuckets()->count())->toBe(1);
+});
+
+test('the time series is bucketed and gap filled from the rollups', function () {
+    $project = Project::factory()->create();
+
+    ingestBatch($project, [
+        ['t' => 'request', 'status_code' => 200, 'duration' => 10, 'user' => '1'],
+        ['t' => 'request', 'status_code' => 500, 'duration' => 30],
+    ]);
+
+    $series = records()->getDashboardStats($project, '1h')['timeSeries'];
+
+    expect($series)->toHaveCount(60);
+
+    $populated = collect($series)->firstWhere('total', 2);
+
+    expect($populated)->not->toBeNull()
+        ->and($populated['ok'])->toBe(1)
+        ->and($populated['server_error'])->toBe(1)
+        ->and($populated['avg_duration'])->toBe(20.0)
+        ->and($populated['active_users'])->toBe(1);
+
+    // Every other slot is zero filled, so the chart keeps its shape.
+    expect(collect($series)->sum('total'))->toBe(2);
+});
+
+test('p95 is read off the histogram instead of being a disguised maximum', function () {
+    $project = Project::factory()->create();
+
+    // Durations are microseconds: 95 jobs at 10ms, 5 stragglers at 5s.
+    $batch = [];
+    for ($i = 0; $i < 95; $i++) {
+        $batch[] = ['t' => 'job-attempt', 'name' => 'J', 'status' => 'processed', 'duration' => 10_000];
+    }
+    for ($i = 0; $i < 5; $i++) {
+        $batch[] = ['t' => 'job-attempt', 'name' => 'J', 'status' => 'processed', 'duration' => 5_000_000];
+    }
+
+    ingestBatch($project, $batch);
+
+    $jobStats = records()->getDashboardStats($project, '1h')['job_stats'];
+
+    // These fields are divided by 1000 for display, so the units are milliseconds.
+    // The old code reported MAX(duration) here, which would have read 5000ms.
+    expect($jobStats['p95_duration'])->toBe(10.0)
+        ->and($jobStats['avg_duration'])->toBe(259.5)
+        ->and($jobStats['total'])->toBe(100)
+        ->and($jobStats['processed'])->toBe(100);
+});
+
+test('overview cards on the type pages read from the rollups', function () {
+    $project = Project::factory()->create();
+
+    ingestBatch($project, [
+        ['t' => 'command', 'command' => 'a', 'exit_code' => 0, 'duration' => 10],
+        ['t' => 'command', 'command' => 'b', 'exit_code' => 1, 'duration' => 30],
+        ['t' => 'cache-event', 'key' => 'k', 'type' => 'hit'],
+        ['t' => 'cache-event', 'key' => 'k', 'type' => 'miss'],
+    ]);
+
+    expect(records()->getCommandStats($project, '1h')['overview'])->toMatchArray([
+        'total' => 2,
+        'success' => 1,
+        'failed' => 1,
+        'avg_duration' => 20.0,
+    ]);
+
+    expect(records()->getCacheStats($project, '1h')['overview'])->toMatchArray([
+        'total' => 2,
+        'hits' => 1,
+        'misses' => 1,
+        'hit_rate' => 50.0,
+    ]);
+});
+
+test('a request with a null user counts as a guest, not as a user named null', function () {
+    $project = Project::factory()->create();
+
+    ingestBatch($project, [
+        ['t' => 'request', 'status_code' => 200, 'user' => '1'],
+        ['t' => 'request', 'status_code' => 200, 'user' => null],
+        ['t' => 'request', 'status_code' => 200],
+    ]);
+
+    $stats = records()->getDashboardStats($project, '1h');
+
+    // The old SQL asked `JSON_EXTRACT(payload,'$.user') IS NOT NULL`, but a JSON
+    // null is not an SQL NULL, so guests were counted as one shared user whose
+    // id was the string "null" — and guest_users_count came out as zero.
+    expect($stats['auth_users_count'])->toBe(1)
+        ->and($stats['guest_users_count'])->toBe(2)
+        ->and($stats['active_users'])->toHaveCount(1)
+        ->and($stats['active_users']->first()->user_id)->toBe('1');
+});
+
+test('the top user panels rank from the user buckets', function () {
+    $project = Project::factory()->create();
+
+    $batch = [];
+    foreach (['a' => 5, 'b' => 3, 'c' => 1] as $user => $requests) {
+        for ($i = 0; $i < $requests; $i++) {
+            $batch[] = ['t' => 'request', 'status_code' => 200, 'user' => $user];
+        }
+    }
+    $batch[] = ['t' => 'exception', 'class' => 'E', 'message' => 'm', 'user' => 'b'];
+    $batch[] = ['t' => 'exception', 'class' => 'E', 'message' => 'm', 'user' => 'b'];
+    $batch[] = ['t' => 'exception', 'class' => 'E', 'message' => 'm', 'user' => 'c'];
+
+    ingestBatch($project, $batch);
+
+    $stats = records()->getDashboardStats($project, '1h');
+
+    $active = $stats['active_users'];
+    expect($active)->toHaveCount(3)
+        ->and($active->first()->user_id)->toBe('a')
+        ->and((int) $active->first()->request_count)->toBe(5);
+
+    $impacted = $stats['impacted_users'];
+    expect($impacted->first()->user_id)->toBe('b')
+        ->and((int) $impacted->first()->error_count)->toBe(2);
+});
+
+test('top user counts survive a second batch in the same bucket', function () {
+    $project = Project::factory()->create();
+
+    ingestBatch($project, [['t' => 'request', 'status_code' => 200, 'user' => 'a']]);
+    ingestBatch($project, [['t' => 'request', 'status_code' => 200, 'user' => 'a']]);
+
+    $active = records()->getDashboardStats($project, '1h')['active_users'];
+
+    expect((int) $active->first()->request_count)->toBe(2);
+});
+
+test('rollups are scoped to their own project', function () {
+    $mine = Project::factory()->create();
+    $theirs = Project::factory()->create();
+
+    ingestBatch($mine, [['t' => 'request', 'status_code' => 200]]);
+    ingestBatch($theirs, [['t' => 'request', 'status_code' => 200], ['t' => 'request', 'status_code' => 200]]);
+
+    expect(records()->getQuickStats($mine, '1h')['requests'])->toBe(1)
+        ->and(records()->getQuickStats($theirs, '1h')['requests'])->toBe(2);
+});

--- a/tests/Feature/RollupDriverSqlTest.php
+++ b/tests/Feature/RollupDriverSqlTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Services\RollupWriter;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Build a query grammar for a driver without opening a connection.
+ *
+ * `getQueryGrammar()` instantiates the grammar but never touches a PDO, so this
+ * works on a machine that has no MySQL or Postgres server — which is the point:
+ * the Postgres branch is exercised even where it cannot be run.
+ */
+function grammarFor(string $driver)
+{
+    $name = $driver.'_probe';
+
+    Config::set("database.connections.{$name}", [
+        'driver' => $driver,
+        'host' => '127.0.0.1',
+        'database' => 'probe',
+        'username' => 'probe',
+        'password' => 'probe',
+        'prefix' => '',
+    ]);
+
+    return DB::connection($name)->getQueryGrammar();
+}
+
+function conflictClauseFor(string $driver, string $table, array $conflict, array $additive, array $max = [], array $min = [], array $overwrite = []): string
+{
+    $writer = app(RollupWriter::class);
+    $method = new ReflectionMethod($writer, 'conflictClause');
+    $method->setAccessible(true);
+
+    return $method->invoke($writer, $driver, grammarFor($driver), $table, $conflict, $additive, $max, $min, $overwrite);
+}
+
+test('the postgres upsert adds onto the existing row via excluded', function () {
+    $sql = conflictClauseFor('pgsql', 'record_rollups', ['project_id', 'type', 'bucket'], ['count'], ['max_duration'], ['min_duration']);
+
+    expect($sql)->toContain('on conflict ("project_id", "type", "bucket") do update set')
+        ->and($sql)->toContain('"count" = "record_rollups"."count" + excluded."count"')
+        // Postgres greatest()/least() already ignore nulls, so no coalesce.
+        ->and($sql)->toContain('"max_duration" = greatest("record_rollups"."max_duration", excluded."max_duration")')
+        ->and($sql)->toContain('"min_duration" = least("record_rollups"."min_duration", excluded."min_duration")')
+        ->and($sql)->not->toContain('values(')
+        ->and($sql)->not->toContain('coalesce');
+});
+
+test('the mysql upsert increments and guards the extremes against nulls', function () {
+    $sql = conflictClauseFor('mysql', 'record_rollups', ['project_id', 'type', 'bucket'], ['count'], ['max_duration'], ['min_duration']);
+
+    expect($sql)->toContain('on duplicate key update')
+        ->and($sql)->toContain('`count` = `count` + values(`count`)')
+        // MySQL greatest(x, null) is null, so both sides are coalesced.
+        ->and($sql)->toContain('`max_duration` = greatest(coalesce(`max_duration`, values(`max_duration`)), coalesce(values(`max_duration`), `max_duration`))')
+        ->and($sql)->not->toContain('excluded.');
+});
+
+test('overwrite columns replace rather than add, on both drivers', function () {
+    $pg = conflictClauseFor('pgsql', 'record_group_rollups', ['project_id', 'type', 'bucket', 'group_key'], ['count'], [], [], ['label', 'sublabel']);
+    $my = conflictClauseFor('mysql', 'record_group_rollups', ['project_id', 'type', 'bucket', 'group_key'], ['count'], [], [], ['label', 'sublabel']);
+
+    expect($pg)->toContain('"label" = excluded."label"')
+        ->and($pg)->toContain('on conflict ("project_id", "type", "bucket", "group_key")')
+        ->and($my)->toContain('`label` = values(`label`)');
+});
+
+test('the conflict target matches each rollup table unique key', function () {
+    // Postgres infers the arbiter index from the conflict columns, so they must
+    // line up with the unique index each migration declares.
+    $cases = [
+        'record_rollups' => ['project_id', 'type', 'bucket'],
+        'record_group_rollups' => ['project_id', 'type', 'bucket', 'group_key'],
+        'record_user_buckets' => ['project_id', 'type', 'bucket', 'user_key'],
+        'record_ip_buckets' => ['project_id', 'type', 'bucket', 'ip'],
+    ];
+
+    foreach ($cases as $table => $conflict) {
+        $sql = conflictClauseFor('pgsql', $table, $conflict, ['count']);
+        $target = '('.implode(', ', array_map(fn ($c) => "\"{$c}\"", $conflict)).')';
+
+        expect($sql)->toContain("on conflict {$target} do update set");
+    }
+});
+
+test('every additive rollup column appears in both drivers upserts', function () {
+    foreach (['pgsql', 'mysql'] as $driver) {
+        $sql = conflictClauseFor($driver, 'record_rollups', ['project_id', 'type', 'bucket'], RollupWriter::additiveColumns(), ['max_duration'], ['min_duration']);
+
+        foreach (RollupWriter::additiveColumns() as $column) {
+            expect($sql)->toContain($column);
+        }
+    }
+});

--- a/tests/Feature/RollupGroupListTest.php
+++ b/tests/Feature/RollupGroupListTest.php
@@ -1,0 +1,271 @@
+<?php
+
+use App\Models\Project;
+use App\Models\RecordGroupRollup;
+use App\Services\IngestService;
+use App\Services\RecordService;
+
+function ingestGroups(Project $project, array $records): void
+{
+    app(IngestService::class)->ingest($project, $records);
+}
+
+function service(): RecordService
+{
+    return app(RecordService::class);
+}
+
+test('the requests list is grouped by fingerprint with its labels', function () {
+    $project = Project::factory()->create();
+
+    ingestGroups($project, [
+        ['t' => 'request', '_group' => 'a', 'method' => 'GET', 'route_path' => '/users', 'status_code' => 200, 'duration' => 10_000],
+        ['t' => 'request', '_group' => 'a', 'method' => 'GET', 'route_path' => '/users', 'status_code' => 500, 'duration' => 30_000],
+        ['t' => 'request', '_group' => 'b', 'method' => 'POST', 'route_path' => '/orders', 'status_code' => 404, 'duration' => 5_000],
+    ]);
+
+    $rows = service()->getRequestStats($project, '1h')['requests'];
+
+    expect($rows->total())->toBe(2);
+
+    $users = collect($rows->items())->firstWhere('hash', 'a');
+
+    expect($users->method)->toBe('GET')
+        ->and($users->path)->toBe('/users')
+        ->and((int) $users->total)->toBe(2)
+        ->and((int) $users->ok_count)->toBe(1)
+        ->and((int) $users->server_error_count)->toBe(1)
+        ->and($users->avg_duration)->toBe(20000.0)
+        ->and((float) $users->max_duration)->toBe(30000.0);
+
+    $orders = collect($rows->items())->firstWhere('hash', 'b');
+    expect((int) $orders->client_error_count)->toBe(1);
+});
+
+test('group rollups are hourly, so a whole day of one route is 24 rows at most', function () {
+    $project = Project::factory()->create();
+
+    $this->travelTo(now()->startOfHour()->addMinutes(2));
+    ingestGroups($project, [['t' => 'request', '_group' => 'a', 'method' => 'GET', 'route_path' => '/', 'status_code' => 200]]);
+
+    $this->travelTo(now()->addMinutes(30));
+    ingestGroups($project, [['t' => 'request', '_group' => 'a', 'method' => 'GET', 'route_path' => '/', 'status_code' => 200]]);
+
+    $this->travelBack();
+
+    $rows = RecordGroupRollup::where('project_id', $project->id)->get();
+
+    expect($rows)->toHaveCount(1)
+        ->and((int) $rows->first()->count)->toBe(2)
+        ->and($rows->first()->bucket->format('i:s'))->toBe('00:00');
+});
+
+test('a group list row reports a real p95 rather than a maximum', function () {
+    $project = Project::factory()->create();
+
+    $batch = [];
+    for ($i = 0; $i < 95; $i++) {
+        $batch[] = ['t' => 'request', '_group' => 'a', 'method' => 'GET', 'route_path' => '/', 'status_code' => 200, 'duration' => 10_000];
+    }
+    for ($i = 0; $i < 5; $i++) {
+        $batch[] = ['t' => 'request', '_group' => 'a', 'method' => 'GET', 'route_path' => '/', 'status_code' => 200, 'duration' => 5_000_000];
+    }
+
+    ingestGroups($project, $batch);
+
+    $row = service()->getRequestStats($project, '1h')['requests']->items()[0];
+
+    expect($row->p95_duration)->toBe(10000.0)
+        ->and((float) $row->max_duration)->toBe(5000000.0);
+});
+
+test('the exceptions list counts distinct affected users', function () {
+    $project = Project::factory()->create();
+
+    ingestGroups($project, [
+        ['t' => 'exception', '_group' => 'boom', 'class' => 'RuntimeException', 'message' => 'boom', 'user' => '1'],
+        ['t' => 'exception', '_group' => 'boom', 'class' => 'RuntimeException', 'message' => 'boom', 'user' => '1'],
+        ['t' => 'exception', '_group' => 'boom', 'class' => 'RuntimeException', 'message' => 'boom', 'user' => '2'],
+        ['t' => 'exception', '_group' => 'boom', 'class' => 'RuntimeException', 'message' => 'boom', 'user' => 'guest_abc'],
+        ['t' => 'exception', '_group' => 'other', 'class' => 'LogicException', 'message' => 'nope', 'user' => '1'],
+    ]);
+
+    $rows = collect(service()->getExceptionStats($project, '1h')['exceptions']->items());
+
+    $boom = $rows->firstWhere('hash', 'boom');
+
+    expect($boom->class)->toBe('RuntimeException')
+        ->and($boom->message)->toBe('boom')
+        ->and((int) $boom->total_count)->toBe(4)
+        // Three of those four carry a user, but only two are real people.
+        ->and($boom->user_count)->toBe(2);
+
+    expect($rows->firstWhere('hash', 'other')->user_count)->toBe(1);
+});
+
+test('the jobs list maps statuses onto its columns', function () {
+    $project = Project::factory()->create();
+
+    ingestGroups($project, [
+        ['t' => 'job-attempt', '_group' => 'j', 'name' => 'SendMail', 'status' => 'processed', 'duration' => 1_000],
+        ['t' => 'job-attempt', '_group' => 'j', 'name' => 'SendMail', 'status' => 'failed', 'duration' => 2_000],
+        ['t' => 'job-attempt', '_group' => 'j', 'name' => 'SendMail', 'status' => 'released', 'duration' => 3_000],
+    ]);
+
+    $row = service()->getJobStats($project, '1h')['jobs']->items()[0];
+
+    expect($row->job_class)->toBe('SendMail')
+        ->and((int) $row->total)->toBe(3)
+        ->and($row->processed_count)->toBe(1)
+        ->and($row->failed_count)->toBe(1);
+});
+
+test('the cache list keeps its per key breakdown and hit rate', function () {
+    $project = Project::factory()->create();
+
+    ingestGroups($project, [
+        ['t' => 'cache-event', '_group' => 'k1', 'key' => 'users:1', 'type' => 'hit'],
+        ['t' => 'cache-event', '_group' => 'k1', 'key' => 'users:1', 'type' => 'hit'],
+        ['t' => 'cache-event', '_group' => 'k1', 'key' => 'users:1', 'type' => 'miss'],
+        ['t' => 'cache-event', '_group' => 'k1', 'key' => 'users:1', 'type' => 'write'],
+        ['t' => 'cache-event', '_group' => 'k1', 'key' => 'users:1', 'type' => 'delete'],
+    ]);
+
+    $row = service()->getCacheStats($project, '1h')['keys']->items()[0];
+
+    expect($row->cache_key)->toBe('users:1')
+        ->and((int) $row->hits)->toBe(2)
+        ->and((int) $row->misses)->toBe(1)
+        ->and((int) $row->writes)->toBe(1)
+        ->and((int) $row->deletes)->toBe(1)
+        ->and($row->hit_rate)->toBe(40.0);
+});
+
+test('the queries list carries the statement and total duration', function () {
+    $project = Project::factory()->create();
+
+    ingestGroups($project, [
+        ['t' => 'query', '_group' => 'q', 'sql' => 'select * from users', 'connection' => 'pgsql', 'duration' => 1_500],
+        ['t' => 'query', '_group' => 'q', 'sql' => 'select * from users', 'connection' => 'pgsql', 'duration' => 2_500],
+    ]);
+
+    $row = service()->getQueryStats($project, '1h')['queries']->items()[0];
+
+    expect($row->sql_query)->toBe('select * from users')
+        ->and($row->db_connection)->toBe('pgsql')
+        ->and($row->total_calls)->toBe(2)
+        ->and($row->total_duration)->toBe(4000.0)
+        ->and($row->avg_duration)->toBe(2000.0);
+});
+
+test('the mail list counts what actually went out', function () {
+    $project = Project::factory()->create();
+
+    ingestGroups($project, [
+        ['t' => 'mail', '_group' => 'm', 'class' => 'WelcomeMail', 'mailer' => 'smtp'],
+        ['t' => 'mail', '_group' => 'm', 'class' => 'WelcomeMail', 'mailer' => 'log'],
+    ]);
+
+    $row = service()->getMailStats($project, '1h')['mailables']->items()[0];
+
+    expect($row->mailable_class)->toBe('WelcomeMail')
+        ->and((int) $row->total)->toBe(2)
+        ->and($row->queued_count)->toBe(1);
+});
+
+test('the notifications list splits sent from failed', function () {
+    $project = Project::factory()->create();
+
+    ingestGroups($project, [
+        ['t' => 'notification', '_group' => 'n', 'class' => 'OrderShipped', 'channel' => 'mail'],
+        ['t' => 'notification', '_group' => 'n', 'class' => 'OrderShipped', 'channel' => 'mail', 'status' => 'failed'],
+    ]);
+
+    $row = service()->getNotificationStats($project, '1h')['notifications']->items()[0];
+
+    expect($row->notification_class)->toBe('OrderShipped')
+        ->and($row->channel)->toBe('mail')
+        ->and($row->sent_count)->toBe(1)
+        ->and($row->failed_count)->toBe(1);
+});
+
+test('the outgoing requests list groups by host', function () {
+    $project = Project::factory()->create();
+
+    ingestGroups($project, [
+        ['t' => 'outgoing-request', '_group' => 'h', 'host' => 'api.stripe.com', 'status_code' => 200, 'duration' => 100],
+        ['t' => 'outgoing-request', '_group' => 'h', 'host' => 'api.stripe.com', 'status' => 'failed', 'duration' => 100],
+    ]);
+
+    $row = service()->getOutgoingRequestStats($project, '1h')['hosts']->items()[0];
+
+    expect($row->host)->toBe('api.stripe.com')
+        ->and((int) $row->total)->toBe(2)
+        ->and((int) $row->ok_count)->toBe(1);
+});
+
+test('the scheduled tasks list keeps the cron expression and next run', function () {
+    $project = Project::factory()->create();
+
+    ingestGroups($project, [
+        ['t' => 'scheduled-task', '_group' => 's', 'command' => 'backup:run', 'cron' => '0 3 * * *', 'exit_code' => 0],
+        ['t' => 'scheduled-task', '_group' => 's', 'command' => 'backup:run', 'cron' => '0 3 * * *', 'status' => 'skipped'],
+    ]);
+
+    $row = service()->getScheduledTaskStats($project, '1h')['tasks']->items()[0];
+
+    expect($row->command)->toBe('backup:run')
+        ->and($row->schedule)->toBe('0 3 * * *')
+        ->and($row->processed_count)->toBe(1)
+        ->and($row->skipped_count)->toBe(1)
+        ->and($row->next_run)->not->toBe('Invalid Schedule');
+});
+
+test('the users list aggregates requests, errors and exceptions per user', function () {
+    $project = Project::factory()->create();
+
+    ingestGroups($project, [
+        ['t' => 'request', '_group' => 'a', 'user' => '5', 'status_code' => 200],
+        ['t' => 'request', '_group' => 'a', 'user' => '5', 'status_code' => 500],
+        ['t' => 'request', '_group' => 'a', 'user' => '5', 'status_code' => 404],
+        ['t' => 'exception', '_group' => 'e', 'class' => 'E', 'message' => 'm', 'user' => '5'],
+        ['t' => 'request', '_group' => 'a', 'user' => 'guest_zz', 'status_code' => 200],
+    ]);
+
+    $rows = service()->getUserStats($project, '1h')['users'];
+
+    // The guest never becomes a row.
+    expect($rows->total())->toBe(1);
+
+    $row = $rows->items()[0];
+
+    expect((string) $row->user_id)->toBe('5')
+        ->and($row->hash)->toBe(md5('5'))
+        ->and((int) $row->total_requests)->toBe(3)
+        ->and((int) $row->error_count)->toBe(2)
+        ->and((int) $row->exception_count)->toBe(1);
+});
+
+test('records without a fingerprint produce no group row', function () {
+    $project = Project::factory()->create();
+
+    ingestGroups($project, [
+        ['t' => 'log', 'level' => 'info', 'message' => 'hello'],
+    ]);
+
+    expect(RecordGroupRollup::where('project_id', $project->id)->count())->toBe(0);
+});
+
+test('group counters accumulate across batches in the same hour', function () {
+    $project = Project::factory()->create();
+
+    ingestGroups($project, [['t' => 'request', '_group' => 'a', 'method' => 'GET', 'route_path' => '/', 'status_code' => 200, 'duration' => 10]]);
+    ingestGroups($project, [['t' => 'request', '_group' => 'a', 'method' => 'GET', 'route_path' => '/', 'status_code' => 200, 'duration' => 30]]);
+
+    $row = RecordGroupRollup::where('project_id', $project->id)->first();
+
+    expect((int) $row->count)->toBe(2)
+        ->and((float) $row->sum_duration)->toBe(40.0)
+        ->and((float) $row->max_duration)->toBe(30.0)
+        ->and((float) $row->min_duration)->toBe(10.0);
+});

--- a/tests/Feature/RollupRetentionTest.php
+++ b/tests/Feature/RollupRetentionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Models\Project;
+use App\Models\RecordRollup;
+use App\Models\RecordUserBucket;
+
+test('rollups outlive raw records so long range charts keep working', function () {
+    // Refreshed, because the database defaults are not hydrated onto the model
+    // the factory just inserted.
+    $project = Project::factory()->create()->fresh();
+
+    expect($project->retention_days)->toBe(7)
+        ->and($project->rollup_retention_days)->toBe(90);
+});
+
+test('buckets past the rollup retention window are pruned', function () {
+    $project = Project::factory()->create(['rollup_retention_days' => 90]);
+
+    $stale = RecordRollup::create([
+        'project_id' => $project->id,
+        'type' => 'request',
+        'bucket' => now()->subDays(120),
+        'count' => 1,
+    ]);
+
+    $fresh = RecordRollup::create([
+        'project_id' => $project->id,
+        'type' => 'request',
+        'bucket' => now()->subDays(30),
+        'count' => 1,
+    ]);
+
+    $this->artisan('model:prune', ['--model' => [RecordRollup::class]])->assertExitCode(0);
+
+    expect(RecordRollup::find($stale->id))->toBeNull()
+        ->and(RecordRollup::find($fresh->id))->not->toBeNull();
+});
+
+test('user buckets are pruned on the same window', function () {
+    $project = Project::factory()->create(['rollup_retention_days' => 90]);
+
+    $stale = RecordUserBucket::create([
+        'project_id' => $project->id,
+        'type' => 'request',
+        'bucket' => now()->subDays(120),
+        'user_key' => '1',
+    ]);
+
+    $fresh = RecordUserBucket::create([
+        'project_id' => $project->id,
+        'type' => 'request',
+        'bucket' => now()->subDays(1),
+        'user_key' => '1',
+    ]);
+
+    $this->artisan('model:prune', ['--model' => [RecordUserBucket::class]])->assertExitCode(0);
+
+    expect(RecordUserBucket::find($stale->id))->toBeNull()
+        ->and(RecordUserBucket::find($fresh->id))->not->toBeNull();
+});
+
+test('a project with retention disabled keeps its rollups', function () {
+    $project = Project::factory()->create(['rollup_retention_days' => 0]);
+
+    $ancient = RecordRollup::create([
+        'project_id' => $project->id,
+        'type' => 'request',
+        'bucket' => now()->subYears(2),
+        'count' => 1,
+    ]);
+
+    $this->artisan('model:prune', ['--model' => [RecordRollup::class]])->assertExitCode(0);
+
+    expect(RecordRollup::find($ancient->id))->not->toBeNull();
+});

--- a/tests/Feature/RollupWriterTest.php
+++ b/tests/Feature/RollupWriterTest.php
@@ -1,0 +1,168 @@
+<?php
+
+use App\Models\Project;
+use App\Models\RecordRollup;
+use App\Services\IngestService;
+use App\Services\RollupWriter;
+
+function rollupFor(Project $project, string $type): ?RecordRollup
+{
+    return RecordRollup::where('project_id', $project->id)->where('type', $type)->first();
+}
+
+function ingestRecords(Project $project, array $records): void
+{
+    app(IngestService::class)->ingest($project, $records);
+}
+
+test('a request contributes its status, duration and user to the bucket', function () {
+    $project = Project::factory()->create();
+
+    ingestRecords($project, [
+        ['t' => 'request', 'status_code' => 200, 'duration' => 30, 'user' => '7'],
+        ['t' => 'request', 'status_code' => 404, 'duration' => 10, 'user' => '7'],
+        ['t' => 'request', 'status_code' => 500, 'duration' => 90],
+    ]);
+
+    $rollup = rollupFor($project, 'request');
+
+    expect($rollup->count)->toBe(3)
+        ->and($rollup->ok_count)->toBe(1)
+        ->and($rollup->client_error_count)->toBe(1)
+        ->and($rollup->server_error_count)->toBe(1)
+        ->and($rollup->authed_count)->toBe(2)
+        ->and((float) $rollup->sum_duration)->toBe(130.0)
+        ->and($rollup->count_duration)->toBe(3)
+        ->and((float) $rollup->max_duration)->toBe(90.0)
+        ->and((float) $rollup->min_duration)->toBe(10.0);
+});
+
+test('counters accumulate when a second batch lands in the same bucket', function () {
+    $project = Project::factory()->create();
+
+    ingestRecords($project, [['t' => 'request', 'status_code' => 200, 'duration' => 30]]);
+    ingestRecords($project, [['t' => 'request', 'status_code' => 200, 'duration' => 70]]);
+
+    $rollup = rollupFor($project, 'request');
+
+    // Laravel's upsert() would have overwritten rather than added.
+    expect($rollup->count)->toBe(2)
+        ->and($rollup->ok_count)->toBe(2)
+        ->and((float) $rollup->sum_duration)->toBe(100.0)
+        ->and((float) $rollup->max_duration)->toBe(70.0)
+        ->and((float) $rollup->min_duration)->toBe(30.0);
+});
+
+test('a batch carrying no durations does not erase the recorded extremes', function () {
+    $project = Project::factory()->create();
+
+    ingestRecords($project, [['t' => 'log', 'level' => 'info', 'duration' => 42]]);
+    ingestRecords($project, [['t' => 'log', 'level' => 'info']]);
+
+    $rollup = rollupFor($project, 'log');
+
+    // GREATEST(x, NULL) is NULL on MySQL and SQLite, so this is a real trap.
+    expect($rollup->count)->toBe(2)
+        ->and($rollup->count_duration)->toBe(1)
+        ->and((float) $rollup->max_duration)->toBe(42.0)
+        ->and((float) $rollup->min_duration)->toBe(42.0);
+});
+
+test('exceptions always count as server errors', function () {
+    $project = Project::factory()->create();
+
+    ingestRecords($project, [
+        ['t' => 'exception', 'class' => 'RuntimeException', 'message' => 'boom'],
+    ]);
+
+    expect(rollupFor($project, 'exception')->server_error_count)->toBe(1);
+});
+
+test('job statuses map onto ok, failed and neutral counters', function () {
+    $project = Project::factory()->create();
+
+    ingestRecords($project, [
+        ['t' => 'job-attempt', 'name' => 'A', 'status' => 'processed', 'duration' => 5],
+        ['t' => 'job-attempt', 'name' => 'A', 'status' => 'failed', 'duration' => 5],
+        ['t' => 'job-attempt', 'name' => 'A', 'status' => 'released', 'duration' => 5],
+    ]);
+
+    $rollup = rollupFor($project, 'job-attempt');
+
+    expect($rollup->ok_count)->toBe(1)
+        ->and($rollup->server_error_count)->toBe(1)
+        ->and($rollup->neutral_count)->toBe(1);
+});
+
+test('cache events split into hits, misses and writes', function () {
+    $project = Project::factory()->create();
+
+    ingestRecords($project, [
+        ['t' => 'cache-event', 'key' => 'a', 'type' => 'hit'],
+        ['t' => 'cache-event', 'key' => 'a', 'type' => 'hit'],
+        ['t' => 'cache-event', 'key' => 'b', 'type' => 'miss'],
+        ['t' => 'cache-event', 'key' => 'b', 'type' => 'write'],
+    ]);
+
+    $rollup = rollupFor($project, 'cache-event');
+
+    expect($rollup->hits)->toBe(2)
+        ->and($rollup->misses)->toBe(1)
+        ->and($rollup->writes)->toBe(1)
+        ->and($rollup->ok_count)->toBe(2)
+        ->and($rollup->server_error_count)->toBe(1);
+});
+
+test('a non numeric outgoing status is not read as a status code', function () {
+    $project = Project::factory()->create();
+
+    ingestRecords($project, [
+        ['t' => 'outgoing-request', 'host' => 'a.test', 'status' => 'failed', 'duration' => 10],
+        ['t' => 'outgoing-request', 'host' => 'a.test', 'status_code' => 200, 'duration' => 10],
+        ['t' => 'outgoing-request', 'host' => 'a.test', 'status' => 503, 'duration' => 10],
+    ]);
+
+    $rollup = rollupFor($project, 'outgoing-request');
+
+    expect($rollup->count)->toBe(3)
+        ->and($rollup->ok_count)->toBe(1)
+        ->and($rollup->server_error_count)->toBe(1)
+        ->and($rollup->client_error_count)->toBe(0);
+});
+
+// Durations arrive in microseconds; the client's StageSensor multiplies
+// elapsed seconds by 1_000_000.
+test('durations land in the right latency histogram bucket', function (float $microseconds, string $column) {
+    $project = Project::factory()->create();
+
+    ingestRecords($project, [['t' => 'query', 'sql' => 'select 1', 'duration' => $microseconds]]);
+
+    expect(rollupFor($project, 'query')->{$column})->toBe(1);
+})->with([
+    'half a millisecond' => [500.0, 'lat_le_1000'],
+    'exactly 1ms' => [1_000.0, 'lat_le_1000'],
+    'just over 1ms' => [1_001.0, 'lat_le_5000'],
+    'a real 325ms request' => [325_225.0, 'lat_le_500000'],
+    'one second' => [1_000_000.0, 'lat_le_1000000'],
+    'slower than ten seconds' => [10_000_001.0, 'lat_le_inf'],
+]);
+
+test('the histogram merges additively across batches', function () {
+    $project = Project::factory()->create();
+
+    ingestRecords($project, [['t' => 'query', 'sql' => 'a', 'duration' => 900]]);
+    ingestRecords($project, [['t' => 'query', 'sql' => 'b', 'duration' => 900]]);
+
+    expect(rollupFor($project, 'query')->lat_le_1000)->toBe(2);
+});
+
+test('every additive column is a real column on the rollup table', function () {
+    $project = Project::factory()->create();
+    ingestRecords($project, [['t' => 'request', 'status_code' => 200]]);
+
+    $rollup = rollupFor($project, 'request');
+
+    foreach (RollupWriter::additiveColumns() as $column) {
+        expect($rollup->getAttributes())->toHaveKey($column);
+    }
+});

--- a/tests/Feature/TenantIsolationTest.php
+++ b/tests/Feature/TenantIsolationTest.php
@@ -1,0 +1,151 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Models\AlertRule;
+use App\Models\Integration;
+use App\Models\Issue;
+use App\Models\Project;
+use App\Models\Team;
+use App\Models\Threshold;
+use App\Models\User;
+
+/**
+ * A user, the team they belong to, and a project in it.
+ */
+function tenant(): array
+{
+    $team = Team::factory()->create();
+    $user = User::factory()->create();
+    $team->members()->attach($user, ['role' => TeamRole::Owner->value]);
+    $project = Project::factory()->create(['team_id' => $team->id]);
+
+    return [$user, $team, $project];
+}
+
+/**
+ * The URL params that place a victim resource under the attacker's own project.
+ */
+function crossTenant(array $attacker, Project $victimProject): array
+{
+    [, $attackerTeam, $attackerProject] = $attacker;
+
+    return [
+        'current_team' => $attackerTeam->slug,
+        'project' => $attackerProject->slug,
+    ];
+}
+
+test('a member cannot read another teams issue by id', function () {
+    $attacker = tenant();
+    [, , $victimProject] = tenant();
+
+    $issue = Issue::create([
+        'project_id' => $victimProject->id,
+        'hash' => 'secret-issue',
+        'type' => 'exception',
+        'title' => 'Secret',
+        'message' => 'confidential',
+        'status' => 'open',
+        'priority' => 'high',
+    ]);
+
+    $this->actingAs($attacker[0])
+        ->get(route('issues.show', [...crossTenant($attacker, $victimProject), 'issue' => $issue->id]))
+        ->assertNotFound();
+});
+
+test('a member cannot overwrite another teams integration secrets', function () {
+    $attacker = tenant();
+    [, , $victimProject] = tenant();
+
+    $integration = Integration::create([
+        'project_id' => $victimProject->id,
+        'name' => 'Ops Slack',
+        'type' => 'slack',
+        'data' => ['webhook_url' => 'https://hooks.slack.com/services/SECRET'],
+        'is_enabled' => true,
+        'status' => 'healthy',
+    ]);
+
+    $this->actingAs($attacker[0])
+        ->patch(route('integrations.update', [...crossTenant($attacker, $victimProject), 'integration' => $integration->id]), [
+            'name' => 'pwned',
+            'is_enabled' => false,
+            'data' => ['webhook_url' => 'https://evil.example/steal'],
+        ])
+        ->assertNotFound();
+
+    // The victim's integration is untouched.
+    expect($integration->fresh()->data['webhook_url'])->toBe('https://hooks.slack.com/services/SECRET')
+        ->and($integration->fresh()->name)->toBe('Ops Slack');
+});
+
+test('a member cannot delete another teams integration', function () {
+    $attacker = tenant();
+    [, , $victimProject] = tenant();
+
+    $integration = Integration::create([
+        'project_id' => $victimProject->id,
+        'name' => 'Ops Slack',
+        'type' => 'slack',
+        'data' => ['webhook_url' => 'https://hooks.slack.com/x'],
+        'is_enabled' => true,
+        'status' => 'healthy',
+    ]);
+
+    $this->actingAs($attacker[0])
+        ->delete(route('integrations.destroy', [...crossTenant($attacker, $victimProject), 'integration' => $integration->id]))
+        ->assertNotFound();
+
+    expect($integration->fresh())->not->toBeNull();
+});
+
+test('a member cannot delete another teams alert rule or threshold', function () {
+    $attacker = tenant();
+    [, , $victimProject] = tenant();
+
+    $rule = AlertRule::create([
+        'project_id' => $victimProject->id,
+        'name' => 'Downtime',
+        'event_type' => 'uptime_down',
+        'settings' => [],
+        'is_enabled' => true,
+    ]);
+
+    $threshold = Threshold::create([
+        'project_id' => $victimProject->id,
+        'type' => 'route',
+        'key' => '/checkout',
+        'value' => 500,
+        'is_enabled' => true,
+    ]);
+
+    $this->actingAs($attacker[0])
+        ->delete(route('alerts.destroy', [...crossTenant($attacker, $victimProject), 'rule' => $rule->id]))
+        ->assertNotFound();
+
+    $this->actingAs($attacker[0])
+        ->delete(route('thresholds.destroy', [...crossTenant($attacker, $victimProject), 'threshold' => $threshold->id]))
+        ->assertNotFound();
+
+    expect($rule->fresh())->not->toBeNull()
+        ->and($threshold->fresh())->not->toBeNull();
+});
+
+test('a member can still reach their own resources', function () {
+    [$user, $team, $project] = tenant();
+
+    $issue = Issue::create([
+        'project_id' => $project->id,
+        'hash' => 'own-issue',
+        'type' => 'exception',
+        'title' => 'Mine',
+        'message' => 'ok',
+        'status' => 'open',
+        'priority' => 'low',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('issues.show', ['current_team' => $team->slug, 'project' => $project->slug, 'issue' => $issue->id]))
+        ->assertOk();
+});

--- a/tests/Feature/ThresholdMonitoringTest.php
+++ b/tests/Feature/ThresholdMonitoringTest.php
@@ -8,6 +8,7 @@ use App\Models\Team;
 use App\Models\Threshold;
 use App\Services\AlertService;
 use App\Services\IngestService;
+use App\Services\RollupWriter;
 use App\Services\SecurityService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Mockery;
@@ -39,13 +40,13 @@ class ThresholdMonitoringTest extends TestCase
             ->with(Mockery::type(Issue::class));
 
         // 4. Ingest a record that exceeds threshold
-        $ingestService = new IngestService($alertService, app(SecurityService::class));
+        $ingestService = new IngestService($alertService, app(SecurityService::class), app(RollupWriter::class));
 
         $records = [
             [
                 't' => 'request',
                 'path' => '/api/test',
-                'duration' => 500, // Exceeds 200ms
+                'duration' => 500_000, // 500ms in microseconds, exceeds the 200ms threshold
                 'method' => 'GET',
             ],
         ];
@@ -86,13 +87,13 @@ class ThresholdMonitoringTest extends TestCase
         $alertService = Mockery::mock(AlertService::class);
         $alertService->shouldNotReceive('notifySlowPerformance');
 
-        $ingestService = new IngestService($alertService, app(SecurityService::class));
+        $ingestService = new IngestService($alertService, app(SecurityService::class), app(RollupWriter::class));
 
         $records = [
             [
                 't' => 'request',
                 'path' => '/api/safe',
-                'duration' => 100, // Within 500ms
+                'duration' => 100_000, // 100ms in microseconds, within the 500ms threshold
                 'method' => 'GET',
             ],
         ];
@@ -103,5 +104,35 @@ class ThresholdMonitoringTest extends TestCase
             'project_id' => $project->id,
             'title' => 'Slow Route: /api/safe',
         ]);
+    }
+
+    public function test_a_threshold_is_compared_in_the_same_unit_as_the_duration()
+    {
+        $team = Team::factory()->create();
+        $project = Project::factory()->create(['team_id' => $team->id]);
+
+        Threshold::create([
+            'project_id' => $project->id,
+            'type' => 'route',
+            'key' => '/api/edge',
+            'value' => 500, // 500 milliseconds
+            'is_enabled' => true,
+        ]);
+
+        $alertService = Mockery::mock(AlertService::class);
+        $alertService->shouldReceive('notifySlowPerformance')->once();
+        $ingestService = new IngestService($alertService, app(SecurityService::class), app(RollupWriter::class));
+
+        // 499ms then 501ms, both in microseconds. The old code compared the raw
+        // microseconds against 500, so 499_000 already "exceeded" 500.
+        $ingestService->ingest($project, [
+            ['t' => 'request', 'path' => '/api/edge', 'duration' => 499_000, 'method' => 'GET'],
+        ]);
+        $this->assertDatabaseMissing('issues', ['project_id' => $project->id, 'title' => 'Slow Route: /api/edge']);
+
+        $ingestService->ingest($project, [
+            ['t' => 'request', 'path' => '/api/edge', 'duration' => 501_000, 'method' => 'GET'],
+        ]);
+        $this->assertDatabaseHas('issues', ['project_id' => $project->id, 'title' => 'Slow Route: /api/edge']);
     }
 }

--- a/tests/Feature/UpdateCheckTest.php
+++ b/tests/Feature/UpdateCheckTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Console\Commands\UpdateLaraOwl;
 use App\Enums\TeamRole;
 use App\Models\Team;
 use App\Models\User;
@@ -251,6 +252,9 @@ test('the update command with --dry-run prints the steps without running them', 
         ->expectsOutputToContain('Dry run')
         ->expectsOutputToContain('git pull --ff-only')
         ->expectsOutputToContain('migrate --force')
+        // Without this an upgraded instance renders an empty dashboard: the new
+        // rollup tables exist but hold nothing.
+        ->expectsOutputToContain('laraowl:rollups:backfill --missing')
         ->assertExitCode(0);
 
     Process::assertNothingRan();
@@ -269,6 +273,7 @@ test('the update command installs the release in maintenance mode', function () 
 
     Process::assertRan(fn ($process) => $process->command === ['git', 'pull', '--ff-only']);
     Process::assertRan(fn ($process) => in_array('migrate', $process->command, true));
+    Process::assertRan(fn ($process) => in_array('laraowl:rollups:backfill', $process->command, true));
     Process::assertRan(fn ($process) => in_array('queue:restart', $process->command, true));
 
     expect(app()->isDownForMaintenance())->toBeFalse();
@@ -294,6 +299,15 @@ test('a failed step aborts the update and lifts maintenance mode', function () {
     Process::assertNotRan(fn ($process) => in_array('migrate', $process->command, true));
     expect(app()->isDownForMaintenance())->toBeFalse();
 })->skip(fn () => ! is_dir(base_path('.git')), 'Requires a git checkout.');
+
+test('the backfill runs after the migrations that create its tables', function () {
+    $command = new UpdateLaraOwl;
+    $steps = (new ReflectionMethod($command, 'steps'))->invoke($command);
+    $labels = array_keys($steps);
+
+    expect(array_search('Running migrations', $labels, true))
+        ->toBeLessThan(array_search('Backfilling dashboard rollups', $labels, true));
+});
 
 test('the update command fails when github cannot be reached', function () {
     Http::fake([

--- a/tests/Feature/UserEmailResolutionTest.php
+++ b/tests/Feature/UserEmailResolutionTest.php
@@ -1,32 +1,27 @@
 <?php
 
 use App\Models\Project;
+use App\Services\IngestService;
 use App\Services\RecordService;
 
 test('user stats resolve real email from user detail records', function () {
     $project = Project::factory()->create();
 
-    $project->records()->create([
-        'type' => 'user',
-        'payload' => [
+    // Ingested, because the users list now ranks over the rollup's user buckets.
+    app(IngestService::class)->ingest($project, [
+        [
             't' => 'user',
             'id' => 123,
             'name' => 'Ada Lovelace',
             'username' => 'ada@example.com',
         ],
-        'created_at' => now(),
-    ]);
-
-    $project->records()->create([
-        'type' => 'request',
-        'fingerprint' => 'request-user-123',
-        'payload' => [
+        [
             't' => 'request',
+            '_group' => 'request-user-123',
             'user' => 123,
             'status_code' => 200,
             'duration' => 25,
         ],
-        'created_at' => now(),
     ]);
 
     $stats = app(RecordService::class)->getUserStats($project, '24h');
@@ -40,27 +35,22 @@ test('user stats resolve real email from user detail records', function () {
 test('dashboard active users resolve real email from user detail records', function () {
     $project = Project::factory()->create();
 
-    $project->records()->create([
-        'type' => 'user',
-        'payload' => [
+    // Ingested rather than inserted, because the top-users panel now ranks over
+    // the rollup's user buckets instead of grouping raw JSON.
+    app(IngestService::class)->ingest($project, [
+        [
             't' => 'user',
             'id' => 456,
             'name' => 'Grace Hopper',
             'username' => 'grace@example.com',
         ],
-        'created_at' => now(),
-    ]);
-
-    $project->records()->create([
-        'type' => 'request',
-        'fingerprint' => 'request-user-456',
-        'payload' => [
+        [
             't' => 'request',
+            '_group' => 'request-user-456',
             'user' => 456,
             'status_code' => 200,
             'duration' => 25,
         ],
-        'created_at' => now(),
     ]);
 
     $stats = app(RecordService::class)->getDashboardStats($project, '24h');


### PR DESCRIPTION
The dashboard no longer computes charts, counters and lists by scanning the raw records table and grouping on JSON. They are served from rollup tables written at ingest time, which takes /requests?period=24h from ~13.8s to ~200ms measured on 2.28M records.

Performance
- Rollup engine: record_rollups (per minute) plus record_group_rollups, record_user_buckets, record_ip_buckets and record_group_user_buckets. Written inside the ingest transaction, so a job retry cannot double count.
- laraowl:rollups:backfill rebuilds them from raw records. laraowl:update runs it with --missing, so an upgraded instance is not left with an empty dashboard.
- Aggregates outlive raw records via projects.rollup_retention_days (90), so long-range charts keep working after raw data is pruned.
- Log search moves from `payload LIKE '%term%'` to a FULLTEXT-indexed message column.
- Drop the single-column indexes on records that were beating the composite indexes in the planner, and lift user_key, ip, trace_id and message out of the JSON payload into indexed columns.
- Load a project's thresholds once per ingest batch instead of once per record.

Security
- Resources under a project were bound by global id without checking they belonged to the project in the URL, so a member of one team could read, modify or delete another team's records, issues, integrations (including webhook secrets), alert rules and thresholds. The project route group is now scope-bound.

Fixed
- The dashboard reloaded in full on every ingested batch, flooding the server with duplicate requests. Reloads are now throttled.
- Request details never showed queries, events, or the request payload.
- Drill-down pages showed only the first 50 rows with no pager, and the pagination arrows pointed at fields that do not exist.
- Slow-performance thresholds compared microsecond durations against millisecond values, firing a thousand times too eagerly.
- Guests were counted as authenticated users in the user panels.