### PR TITLE
Add ExceptionTrace class and fix auth redirect behavior

### DIFF
--- a/app/Http/Controllers/Projects/IssueController.php
+++ b/app/Http/Controllers/Projects/IssueController.php
@@ -7,6 +7,7 @@ use App\Models\Issue;
 use App\Models\Project;
 use App\Models\Team;
 use App\Services\IssueService;
+use App\Support\ExceptionTrace;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -43,6 +44,10 @@ class IssueController extends Controller
     public function show(Team $current_team, Project $project, Issue $issue): Response
     {
         $issue->load(['assignee', 'records' => fn ($q) => $q->latest()->limit(1), 'activities.user']);
+
+        if ($record = $issue->records->first()) {
+            $record->payload = ExceptionTrace::normalize($record->payload);
+        }
 
         return Inertia::render('projects/issues/show', [
             'issue' => $issue,

--- a/app/Http/Controllers/Projects/RecordController.php
+++ b/app/Http/Controllers/Projects/RecordController.php
@@ -7,6 +7,7 @@ use App\Models\Project;
 use App\Models\Record;
 use App\Models\Team;
 use App\Services\RecordService;
+use App\Support\ExceptionTrace;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
@@ -229,7 +230,7 @@ class RecordController extends Controller
 
         return Inertia::render($component, [
             'hash' => $hash,
-            'meta' => $first ? $first->payload : [],
+            'meta' => $first ? ExceptionTrace::normalize($first->payload) : [],
             'records' => $history,
             'period' => $period,
             'from' => $from,

--- a/app/Http/Middleware/CheckOnboarding.php
+++ b/app/Http/Middleware/CheckOnboarding.php
@@ -21,6 +21,10 @@ class CheckOnboarding
             return $next($request);
         }
 
+        if ($request->routeIs('invitations.accept')) {
+            return $next($request);
+        }
+
         // 1. Check if user has any teams
         if ($user->teams()->count() === 0) {
             if (! $request->routeIs('teams.create') && ! $request->routeIs('teams.store') && ! $request->routeIs('logout')) {

--- a/app/Http/Responses/LoginResponse.php
+++ b/app/Http/Responses/LoginResponse.php
@@ -16,7 +16,7 @@ class LoginResponse implements LoginResponseContract
         $team = $user?->currentTeam ?? $user?->personalTeam();
 
         if (! $team) {
-            return redirect()->route('teams.create');
+            return redirect()->intended(route('teams.create'));
         }
 
         URL::defaults(['current_team' => $team->slug]);

--- a/app/Http/Responses/RegisterResponse.php
+++ b/app/Http/Responses/RegisterResponse.php
@@ -16,7 +16,7 @@ class RegisterResponse implements RegisterResponseContract
         $team = $user?->currentTeam ?? $user?->personalTeam();
 
         if (! $team) {
-            return redirect()->route('teams.create');
+            return redirect()->intended(route('teams.create'));
         }
 
         URL::defaults(['current_team' => $team->slug]);

--- a/app/Http/Responses/TwoFactorLoginResponse.php
+++ b/app/Http/Responses/TwoFactorLoginResponse.php
@@ -16,7 +16,7 @@ class TwoFactorLoginResponse implements TwoFactorLoginResponseContract
         $team = $user?->currentTeam ?? $user?->personalTeam();
 
         if (! $team) {
-            return redirect()->route('teams.create');
+            return redirect()->intended(route('teams.create'));
         }
 
         URL::defaults(['current_team' => $team->slug]);

--- a/app/Support/ExceptionTrace.php
+++ b/app/Support/ExceptionTrace.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Support;
+
+final class ExceptionTrace
+{
+    /**
+     * Normalize the client's JSON-encoded exception trace for dashboard views.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public static function normalize(array $payload): array
+    {
+        $trace = $payload['stack'] ?? $payload['trace'] ?? [];
+
+        if (is_string($trace)) {
+            $trace = json_decode($trace, true);
+        }
+
+        if (! is_array($trace)) {
+            $trace = [];
+        }
+
+        $payload['stack'] = array_values(array_map(
+            self::normalizeFrame(...),
+            array_filter($trace, 'is_array'),
+        ));
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $frame
+     * @return array<string, mixed>
+     */
+    private static function normalizeFrame(array $frame): array
+    {
+        $file = is_string($frame['file'] ?? null) ? $frame['file'] : '';
+        $line = is_numeric($frame['line'] ?? null) ? (int) $frame['line'] : null;
+
+        if ($line === null && preg_match('/^(.*):(\d+)$/s', $file, $matches) === 1) {
+            $file = $matches[1];
+            $line = (int) $matches[2];
+        }
+
+        $source = is_string($frame['source'] ?? null) ? $frame['source'] : '';
+        [$class, $type, $function] = self::parseSource($source);
+        $preview = is_array($frame['preview'] ?? null)
+            ? $frame['preview']
+            : (is_array($frame['code'] ?? null) ? $frame['code'] : null);
+
+        return array_merge($frame, [
+            'file' => $file,
+            'line' => $line,
+            'class' => $frame['class'] ?? $class,
+            'type' => $frame['type'] ?? $type,
+            'function' => $frame['function'] ?? $function,
+            'preview' => $preview,
+            'snippet' => $frame['snippet'] ?? self::snippet($preview),
+        ]);
+    }
+
+    /**
+     * @return array{string, string, string}
+     */
+    private static function parseSource(string $source): array
+    {
+        $callable = preg_replace('/\(.*$/s', '', $source) ?? '';
+
+        if (preg_match('/^(.*)(::|->)([^:>]+)$/s', $callable, $matches) === 1) {
+            return [$matches[1], $matches[2], $matches[3]];
+        }
+
+        return ['', '', $callable];
+    }
+
+    /**
+     * @param  array<array-key, mixed>|null  $preview
+     */
+    private static function snippet(?array $preview): ?string
+    {
+        if ($preview === null) {
+            return null;
+        }
+
+        return implode("\n", array_map(
+            static fn (mixed $line): string => is_scalar($line) || $line === null ? (string) $line : '',
+            array_values($preview),
+        ));
+    }
+}

--- a/resources/js/pages/projects/issues/show.tsx
+++ b/resources/js/pages/projects/issues/show.tsx
@@ -88,7 +88,7 @@ export default function IssueShow({
         }
     };
 
-    const stackTrace = Array.isArray(payload.trace) ? payload.trace : [];
+    const stackTrace = Array.isArray(payload.stack) ? payload.stack : [];
 
     return (
         <div className="mx-auto max-w-[1600px] animate-in space-y-6 duration-700 fade-in slide-in-from-bottom-4">

--- a/tests/Feature/ExceptionTraceViewTest.php
+++ b/tests/Feature/ExceptionTraceViewTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Models\Project;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\IngestService;
+
+test('exception detail views receive a normalized stack trace', function () {
+    $team = Team::factory()->create();
+    $user = User::factory()->create();
+    $team->members()->attach($user, ['role' => TeamRole::Owner->value]);
+    $project = Project::factory()->create(['team_id' => $team->id]);
+
+    app(IngestService::class)->ingest($project, [[
+        't' => 'exception',
+        '_group' => 'checkout-exception',
+        'class' => 'RuntimeException',
+        'message' => 'Payment failed',
+        'trace' => json_encode([[
+            'file' => 'app/Services/Checkout.php:42',
+            'source' => 'App\\Services\\Checkout->charge(string)',
+            'code' => ['42' => 'throw new RuntimeException;'],
+        ]], JSON_THROW_ON_ERROR),
+    ]]);
+
+    $routeParameters = [
+        'current_team' => $team->slug,
+        'project' => $project->slug,
+    ];
+
+    $this->actingAs($user)
+        ->get(route('exceptions.show', [...$routeParameters, 'hash' => 'checkout-exception']))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('projects/exceptions/show')
+            ->where('meta.stack.0.file', 'app/Services/Checkout.php')
+            ->where('meta.stack.0.line', 42)
+            ->where('meta.stack.0.function', 'charge')
+            ->where('meta.stack.0.preview.42', 'throw new RuntimeException;')
+        );
+
+    $issue = $project->issues()->firstOrFail();
+
+    $this->actingAs($user)
+        ->get(route('issues.show', [...$routeParameters, 'issue' => $issue->id]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('projects/issues/show')
+            ->where('issue.records.0.payload.stack.0.file', 'app/Services/Checkout.php')
+            ->where('issue.records.0.payload.stack.0.line', 42)
+            ->where('issue.records.0.payload.stack.0.snippet', 'throw new RuntimeException;')
+        );
+});

--- a/tests/Feature/Teams/TeamInvitationTest.php
+++ b/tests/Feature/Teams/TeamInvitationTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Enums\TeamRole;
+use App\Http\Middleware\CheckOnboarding;
+use App\Models\Project;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
@@ -155,6 +157,114 @@ test('team invitations can be accepted', function () {
 
     expect($invitedUser->fresh()->belongsToTeam($team))->toBeTrue();
     expect($invitation->fresh()->accepted_at)->not->toBeNull();
+});
+
+test('onboarding does not intercept invitation acceptance', function () {
+    $owner = User::factory()->create();
+    $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
+    $team = Team::factory()->create();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $invitation = TeamInvitation::factory()->create([
+        'team_id' => $team->id,
+        'email' => $invitedUser->email,
+        'invited_by' => $owner->id,
+    ]);
+
+    $this->withMiddleware(CheckOnboarding::class)
+        ->actingAs($invitedUser)
+        ->get(route('invitations.accept', $invitation))
+        ->assertRedirect('/dashboard');
+
+    expect($invitedUser->fresh()->belongsToTeam($team))->toBeTrue()
+        ->and($invitedUser->fresh()->current_team_id)->toBe($team->id);
+
+    $this->get('/dashboard')->assertRedirect(route('dashboard', [
+        'current_team' => $team->slug,
+        'project' => $project->slug,
+    ]));
+});
+
+test('a teamless user returns to the invitation after logging in', function () {
+    $owner = User::factory()->create();
+    $team = Team::factory()->create();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $invitedUser = User::create([
+        'name' => 'Invited User',
+        'email' => 'invited@example.com',
+        'password' => 'password',
+    ]);
+
+    $invitation = TeamInvitation::factory()->create([
+        'team_id' => $team->id,
+        'email' => $invitedUser->email,
+        'invited_by' => $owner->id,
+    ]);
+
+    $acceptUrl = route('invitations.accept', $invitation);
+
+    $this->withMiddleware(CheckOnboarding::class)
+        ->get($acceptUrl)
+        ->assertRedirect(route('login'));
+
+    $this->post(route('login.store'), [
+        'email' => $invitedUser->email,
+        'password' => 'password',
+    ])->assertRedirect($acceptUrl);
+
+    $this->get($acceptUrl)->assertRedirect('/dashboard');
+
+    expect($invitedUser->fresh()->belongsToTeam($team))->toBeTrue()
+        ->and($invitedUser->fresh()->current_team_id)->toBe($team->id)
+        ->and($invitation->fresh()->accepted_at)->not->toBeNull();
+
+    $this->get('/dashboard')->assertRedirect(route('dashboard', [
+        'current_team' => $team->slug,
+        'project' => $project->slug,
+    ]));
+});
+
+test('a new user joins the inviting team after registering', function () {
+    $owner = User::factory()->create();
+    $team = Team::factory()->create();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $invitation = TeamInvitation::factory()->create([
+        'team_id' => $team->id,
+        'email' => 'new-user@example.com',
+        'invited_by' => $owner->id,
+    ]);
+
+    $acceptUrl = route('invitations.accept', $invitation);
+
+    $this->withMiddleware(CheckOnboarding::class)
+        ->get($acceptUrl)
+        ->assertRedirect(route('login'));
+
+    $this->post(route('register.store'), [
+        'name' => 'New User',
+        'email' => $invitation->email,
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ])->assertRedirect($acceptUrl);
+
+    $this->get($acceptUrl)->assertRedirect('/dashboard');
+
+    $user = User::where('email', $invitation->email)->firstOrFail();
+
+    expect($user->belongsToTeam($team))->toBeTrue()
+        ->and($user->current_team_id)->toBe($team->id)
+        ->and($invitation->fresh()->accepted_at)->not->toBeNull();
+
+    $this->get('/dashboard')->assertRedirect(route('dashboard', [
+        'current_team' => $team->slug,
+        'project' => $project->slug,
+    ]));
 });
 
 test('team invitations cannot be accepted by uninvited user', function () {

--- a/tests/Unit/ExceptionTraceTest.php
+++ b/tests/Unit/ExceptionTraceTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use App\Support\ExceptionTrace;
+
+test('it normalizes the client exception trace shape', function () {
+    $payload = ExceptionTrace::normalize([
+        'trace' => json_encode([
+            [
+                'file' => 'app/Services/Checkout.php:42',
+                'source' => 'App\\Services\\Checkout->charge(string, int)',
+                'code' => [
+                    '41' => '    $gateway->prepare();',
+                    '42' => '    $gateway->charge();',
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR),
+    ]);
+
+    expect($payload['stack'])->toHaveCount(1)
+        ->and($payload['stack'][0])->toMatchArray([
+            'file' => 'app/Services/Checkout.php',
+            'line' => 42,
+            'class' => 'App\\Services\\Checkout',
+            'type' => '->',
+            'function' => 'charge',
+            'preview' => [
+                '41' => '    $gateway->prepare();',
+                '42' => '    $gateway->charge();',
+            ],
+            'snippet' => "    \$gateway->prepare();\n    \$gateway->charge();",
+        ]);
+});
+
+test('it preserves an already normalized stack', function () {
+    $payload = ExceptionTrace::normalize([
+        'stack' => [[
+            'file' => 'C:\\app\\Handler.php',
+            'line' => 17,
+            'class' => 'Handler',
+            'type' => '::',
+            'function' => 'run',
+            'preview' => ['17' => 'throw new Exception;'],
+            'snippet' => 'throw new Exception;',
+        ]],
+    ]);
+
+    expect($payload['stack'][0])->toMatchArray([
+        'file' => 'C:\\app\\Handler.php',
+        'line' => 17,
+        'class' => 'Handler',
+        'type' => '::',
+        'function' => 'run',
+        'snippet' => 'throw new Exception;',
+    ]);
+});
+
+test('it handles malformed traces without breaking the detail page', function () {
+    expect(ExceptionTrace::normalize(['trace' => '{not-json}'])['stack'])->toBe([])
+        ->and(ExceptionTrace::normalize(['trace' => null])['stack'])->toBe([]);
+});


### PR DESCRIPTION
## Fixed

- Fixed blank stack traces and missing code previews on exception detail pages.
- Fixed team invitations so invited users join the correct team after logging in or registering, without being redirected through team and project onboarding.