### PR TITLE
fix(composer): stop reading app version from composer.json

### DIFF
--- a/app/Support/Version.php
+++ b/app/Support/Version.php
@@ -5,19 +5,22 @@ namespace App\Support;
 class Version
 {
     /**
-     * The memoized version, so composer.json is only read once per process.
+     * The version this instance of LaraOwl is running.
+     *
+     * Bumped by hand on each tagged release — mirrors how
+     * Illuminate\Foundation\Application::VERSION is maintained, instead of
+     * a manual "version" key in composer.json (which composer validate
+     * --strict warns against for packages, and which isn't authoritative
+     * once someone patches the code without re-tagging).
      */
-    protected static ?string $current = null;
+    const CURRENT = '1.1.1';
 
     /**
      * Get the version this instance of LaraOwl is running.
-     *
-     * The version key in composer.json is the single source of truth and is
-     * bumped when a release is tagged.
      */
     public static function current(): string
     {
-        return static::$current ??= static::readFromComposerFile();
+        return static::CURRENT;
     }
 
     /**
@@ -38,31 +41,5 @@ class Version
             static::normalize(static::current()),
             '>',
         );
-    }
-
-    /**
-     * Forget the memoized version. Intended for tests.
-     */
-    public static function flush(): void
-    {
-        static::$current = null;
-    }
-
-    /**
-     * Read the version key out of the root composer.json.
-     */
-    protected static function readFromComposerFile(): string
-    {
-        $path = base_path('composer.json');
-
-        if (! is_readable($path)) {
-            return '0.0.0';
-        }
-
-        $composer = json_decode((string) file_get_contents($path), true);
-
-        return is_array($composer) && is_string($composer['version'] ?? null)
-            ? $composer['version']
-            : '0.0.0';
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "$schema": "https://getcomposer.org/schema.json",
     "name": "laraowl/laraowl",
     "type": "project",
-    "version": "1.1.1",
     "description": "LaraOwl - The ultimate open-source, self-hosted monitoring platform for Laravel.",
     "keywords": [
         "laravel",

--- a/tests/Feature/UpdateCheckTest.php
+++ b/tests/Feature/UpdateCheckTest.php
@@ -52,14 +52,11 @@ function instanceOperator(): User
 }
 
 beforeEach(function () {
-    Version::flush();
     config(['laraowl.update_check.enabled' => true]);
 });
 
-test('the current version is read from composer.json', function () {
-    $composer = json_decode((string) file_get_contents(base_path('composer.json')), true);
-
-    expect(Version::current())->toBe($composer['version'])
+test('the current version is a hardcoded, well-formed semver constant', function () {
+    expect(Version::current())->toBe(Version::CURRENT)
         ->and(Version::current())->toMatch('/^\d+\.\d+\.\d+$/');
 });
 


### PR DESCRIPTION
## Problem

The Docker build (`docker/Dockerfile`) runs `composer validate --strict`. It warns on composer.json's manual `"version": "1.1.1"` field:

```
# General warnings
- The version field is present, it is recommended to leave it out if the package is published on Packagist.
```

Composer's own guidance is that version belongs to VCS tags, not a hand-maintained key — it drifts from what's actually installed/running.

## Root cause

`App\Support\Version::current()` read that field directly (`file_get_contents`/`json_decode` against `composer.json`), so it was the one thing in the app actually depending on it — simply deleting the field (my first pass at this PR) would have silently broken the update-checker, since `Version::current()` would fall back to `'0.0.0'` forever.

## Fix

Replaces the composer.json read with a `Version::CURRENT` class constant, bumped by hand on each tagged release — the same pattern `Illuminate\Foundation\Application::VERSION` uses for the Laravel framework itself, for the same reason (no file I/O, no dependency on install-time metadata, always reflects the code that's actually running). `Version::current()`'s public API is unchanged, so every caller (`UpdateService`, `HandleInertiaRequests`, `Release`) is unaffected.

Also drops the now-pointless `Version::flush()`/memoization (a constant needs no cache to invalidate) and updates the one test (`tests/Feature/UpdateCheckTest.php`) that asserted against composer.json's field directly.

## Testing

- `composer validate --strict` → exit 0
- Full Pest suite → 229 passed, 2 pre-existing skips (unrelated, require real git/network)
- `vendor/bin/pint --dirty` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)