### PR TITLE
fix: chart exceptions on the dashboard by their own time series

### DIFF
--- a/app/Services/RecordService.php
+++ b/app/Services/RecordService.php
@@ -117,6 +117,7 @@ class RecordService
             'total_exceptions' => (int) $exceptionStats->total,
             'recent_issues' => $project->issues()->where('status', 'open')->latest('last_seen_at')->limit(5)->get(),
             'timeSeries' => $this->getDetailedTimeSeries($project, 'request', $period, $from, $to),
+            'exceptionTimeSeries' => $this->getDetailedTimeSeries($project, 'exception', $period, $from, $to),
             'job_stats' => [
                 'total' => (int) $jobStats->total,
                 'processed' => (int) $jobStats->ok,

--- a/resources/js/pages/dashboard/index.tsx
+++ b/resources/js/pages/dashboard/index.tsx
@@ -32,6 +32,7 @@ export default function Dashboard({
     duration_stats,
     total_exceptions,
     timeSeries,
+    exceptionTimeSeries,
     job_stats,
     impacted_users,
     active_users,
@@ -54,6 +55,12 @@ export default function Dashboard({
         });
 
     useLiveReload(currentProject?.id);
+
+    const exceptionSeries = exceptionTimeSeries?.slice(-20) || [];
+    const maxExceptionCount = exceptionSeries.reduce(
+        (max: number, d: any) => Math.max(max, d.total || 0),
+        0,
+    );
 
     return (
         <>
@@ -568,30 +575,25 @@ export default function Dashboard({
 
                             <div className="mt-auto pt-8">
                                 <div className="mb-8 flex h-[100px] w-full items-end gap-1">
-                                    {timeSeries
-                                        ?.slice(-20)
-                                        .map((d: any, i: number) => (
+                                    {exceptionSeries.map(
+                                        (d: any, i: number) => (
                                             <div
                                                 key={i}
                                                 className="group relative flex-1 rounded-t-sm bg-red-500/10"
                                                 style={{
-                                                    height: `${total_exceptions > 0 ? Math.min(100, (((d.client_error || 0) + (d.server_error || 0)) / total_exceptions) * 100) : 0}%`,
+                                                    height: `${maxExceptionCount > 0 ? Math.min(100, ((d.total || 0) / maxExceptionCount) * 100) : 0}%`,
                                                     minHeight:
-                                                        (d.client_error || 0) +
-                                                            (d.server_error ||
-                                                                0) >
-                                                        0
+                                                        (d.total || 0) > 0
                                                             ? '4px'
                                                             : '2px',
                                                 }}
                                             >
-                                                {(d.client_error || 0) +
-                                                    (d.server_error || 0) >
-                                                    0 && (
+                                                {(d.total || 0) > 0 && (
                                                     <div className="absolute inset-0 rounded-t-sm bg-red-500" />
                                                 )}
                                             </div>
-                                        ))}
+                                        ),
+                                    )}
                                 </div>
                                 <div className="mb-6 flex items-center gap-4 text-[9px] font-black tracking-widest text-muted-foreground/60 uppercase">
                                     <div className="flex items-center gap-1.5">

--- a/tests/Feature/RollupDashboardTest.php
+++ b/tests/Feature/RollupDashboardTest.php
@@ -160,6 +160,32 @@ test('the time series is bucketed and gap filled from the rollups', function () 
     expect(collect($series)->sum('total'))->toBe(2);
 });
 
+test('the exception time series counts exceptions, not requests', function () {
+    $project = Project::factory()->create();
+
+    ingestBatch($project, [
+        ['t' => 'request', 'status_code' => 200, 'duration' => 10, 'user' => '1'],
+        ['t' => 'request', 'status_code' => 500, 'duration' => 30],
+        ['t' => 'exception', 'class' => 'E', 'message' => 'm'],
+        ['t' => 'exception', 'class' => 'E', 'message' => 'm'],
+        ['t' => 'exception', 'class' => 'E', 'message' => 'm'],
+    ]);
+
+    $stats = records()->getDashboardStats($project, '1h');
+
+    expect($stats['exceptionTimeSeries'])->toHaveCount(60);
+
+    // The dashboard's request series mixes in the requests above, so its
+    // populated slot totals 2 — the exception series must not be that.
+    $populated = collect($stats['exceptionTimeSeries'])->firstWhere('total', '>', 0);
+
+    expect($populated)->not->toBeNull()
+        ->and($populated['total'])->toBe(3)
+        ->and($populated['server_error'])->toBe(3);
+
+    expect(collect($stats['exceptionTimeSeries'])->sum('total'))->toBe(3);
+});
+
 test('p95 is read off the histogram instead of being a disguised maximum', function () {
     $project = Project::factory()->create();
 


### PR DESCRIPTION
The Exceptions Overview card read the dashboard's `timeSeries` prop, which `RecordService::getDashboardStats()` computed from 'request' rollups. The card then divided that request 4xx/5xx count by total_exceptions (an unrelated metric), so the bars came out empty or meaningless.

Adds a dedicated `exceptionTimeSeries` built from the 'exception' rollups and has the card render bars scaled to the busiest bucket in the visible window instead of an unrelated total.