### PR TITLE
fix: split dashboard requests chart into authenticated vs guest bars

### DIFF
--- a/app/Services/RecordService.php
+++ b/app/Services/RecordService.php
@@ -762,6 +762,7 @@ class RecordService
                 $sum('hits', 'hits'),
                 $sum('misses', 'misses'),
                 $sum('writes', 'writes'),
+                $sum('authed_count', 'authed'),
                 DB::raw('SUM('.$this->col('sum_duration').') / NULLIF(SUM('.$this->col('count_duration').'), 0) as avg_duration'),
             ])
             ->groupBy('minute')
@@ -786,6 +787,7 @@ class RecordService
         $results = $results->mapWithKeys(function ($row) use ($activeUsers, $groupsByMinute) {
             $key = $this->seriesKey($row->minute, $groupsByMinute);
             $userSlot = $groupsByMinute ? Carbon::parse($row->minute)->format('Y-m-d H') : $row->minute;
+            $authed = (int) $row->authed;
 
             return [$key => [
                 'minute' => $key,
@@ -799,6 +801,8 @@ class RecordService
                 'writes' => (int) $row->writes,
                 'active_users' => $activeUsers[$userSlot] ?? 0,
                 'total_requests' => (int) $row->total,
+                'authed' => $authed,
+                'guest' => max((int) $row->total - $authed, 0),
             ]];
         });
 
@@ -860,6 +864,8 @@ class RecordService
                     'writes' => 0,
                     'active_users' => 0,
                     'total_requests' => 0,
+                    'authed' => 0,
+                    'guest' => 0,
                 ];
             }
         }

--- a/resources/js/pages/dashboard/index.tsx
+++ b/resources/js/pages/dashboard/index.tsx
@@ -934,14 +934,28 @@ export default function Dashboard({
                                                                     }
                                                                 </div>
                                                                 <div className="flex items-center gap-2">
-                                                                    <div className="h-2 w-2 rounded-full bg-orange-500" />
+                                                                    <div className="h-2 w-2 rounded-full bg-emerald-500" />
                                                                     <span className="text-[10px] font-medium text-muted-foreground uppercase">
-                                                                        Requests:
+                                                                        Auth:
                                                                     </span>
                                                                     <span className="text-[10px] font-bold text-foreground">
                                                                         {formatCompactNumber(
                                                                             payload[0]
-                                                                                .value,
+                                                                                .payload
+                                                                                .authed,
+                                                                        )}
+                                                                    </span>
+                                                                </div>
+                                                                <div className="flex items-center gap-2">
+                                                                    <div className="h-2 w-2 rounded-full bg-orange-500" />
+                                                                    <span className="text-[10px] font-medium text-muted-foreground uppercase">
+                                                                        Guest:
+                                                                    </span>
+                                                                    <span className="text-[10px] font-bold text-foreground">
+                                                                        {formatCompactNumber(
+                                                                            payload[0]
+                                                                                .payload
+                                                                                .guest,
                                                                         )}
                                                                     </span>
                                                                 </div>
@@ -953,7 +967,13 @@ export default function Dashboard({
                                                 }}
                                             />
                                             <Bar
-                                                dataKey="total"
+                                                dataKey="authed"
+                                                stackId="requests"
+                                                fill="#10b981"
+                                            />
+                                            <Bar
+                                                dataKey="guest"
+                                                stackId="requests"
                                                 fill="#f59e0b"
                                                 radius={[1, 1, 0, 0]}
                                             />

--- a/tests/Feature/RollupDashboardTest.php
+++ b/tests/Feature/RollupDashboardTest.php
@@ -277,3 +277,30 @@ test('rollups are scoped to their own project', function () {
     expect(records()->getQuickStats($mine, '1h')['requests'])->toBe(1)
         ->and(records()->getQuickStats($theirs, '1h')['requests'])->toBe(2);
 });
+
+test('the time series splits authenticated requests from guest requests per bucket', function () {
+    $project = Project::factory()->create();
+
+    ingestBatch($project, [
+        ['t' => 'request', 'status_code' => 200, 'user' => '1'],
+        ['t' => 'request', 'status_code' => 200, 'user' => '2'],
+        ['t' => 'request', 'status_code' => 200],
+    ]);
+
+    $series = records()->getDashboardStats($project, '1h')['timeSeries'];
+
+    $populated = collect($series)->firstWhere('total', 3);
+
+    // The legend above the chart reports 2 auth / 1 guest for the period; the
+    // bars must be able to reproduce that same split per bucket.
+    expect($populated)->not->toBeNull()
+        ->and($populated['authed'])->toBe(2)
+        ->and($populated['guest'])->toBe(1);
+
+    // Every zero-filled slot must also carry the split keys so the stacked
+    // bars don't blow up on undefined values.
+    $empty = collect($series)->firstWhere('total', 0);
+
+    expect($empty['authed'])->toBe(0)
+        ->and($empty['guest'])->toBe(0);
+});


### PR DESCRIPTION
The Requests card's legend showed auth_users_count/guest_users_count as period totals, but the bar chart beneath it plotted a single undifferentiated "total" per time bucket from `getDetailedTimeSeries()`, so the chart never reflected the split the legend promised.

`record_rollups` already tracks `authed_count` per bucket, so this sums it alongside the existing total and derives guest as the remainder. The chart now renders two stacked bars (auth/guest) per bucket instead of one.

Touches the same test file as #34 (fix/dashboard-exceptions-chart) — rebased so the new test lands at the end of the file instead of the same insertion point, so the two merge cleanly in either order.