### PR TITLE
fix: classify scheduled-task rollups by status instead of exit_code

### DIFF
--- a/app/Services/RollupWriter.php
+++ b/app/Services/RollupWriter.php
@@ -686,13 +686,12 @@ class RollupWriter
      */
     protected function applyScheduledTask(array &$deltas, array $payload): void
     {
-        if (($payload['status'] ?? null) === 'skipped') {
-            $deltas['neutral_count'] = 1;
-
-            return;
-        }
-
-        $this->applyExitCode($deltas, $payload);
+        match ($payload['status'] ?? null) {
+            'skipped' => $deltas['neutral_count'] = 1,
+            'processed' => $deltas['ok_count'] = 1,
+            'failed' => $deltas['server_error_count'] = 1,
+            default => null,
+        };
     }
 
     /**

--- a/tests/Feature/RollupGroupListTest.php
+++ b/tests/Feature/RollupGroupListTest.php
@@ -208,7 +208,7 @@ test('the scheduled tasks list keeps the cron expression and next run', function
     $project = Project::factory()->create();
 
     ingestGroups($project, [
-        ['t' => 'scheduled-task', '_group' => 's', 'command' => 'backup:run', 'cron' => '0 3 * * *', 'exit_code' => 0],
+        ['t' => 'scheduled-task', '_group' => 's', 'command' => 'backup:run', 'cron' => '0 3 * * *', 'status' => 'processed'],
         ['t' => 'scheduled-task', '_group' => 's', 'command' => 'backup:run', 'cron' => '0 3 * * *', 'status' => 'skipped'],
     ]);
 

--- a/tests/Feature/RollupWriterTest.php
+++ b/tests/Feature/RollupWriterTest.php
@@ -94,6 +94,22 @@ test('job statuses map onto ok, failed and neutral counters', function () {
         ->and($rollup->neutral_count)->toBe(1);
 });
 
+test('scheduled task statuses map onto ok, failed and neutral counters', function () {
+    $project = Project::factory()->create();
+
+    ingestRecords($project, [
+        ['t' => 'scheduled-task', 'command' => 'backup:run', 'status' => 'processed'],
+        ['t' => 'scheduled-task', 'command' => 'backup:run', 'status' => 'failed'],
+        ['t' => 'scheduled-task', 'command' => 'backup:run', 'status' => 'skipped'],
+    ]);
+
+    $rollup = rollupFor($project, 'scheduled-task');
+
+    expect($rollup->ok_count)->toBe(1)
+        ->and($rollup->server_error_count)->toBe(1)
+        ->and($rollup->neutral_count)->toBe(1);
+});
+
 test('cache events split into hits, misses and writes', function () {
     $project = Project::factory()->create();
 


### PR DESCRIPTION
`RollupWriter::applyScheduledTask()` delegated any non-skipped scheduled-task payload to `applyExitCode()`, which reads `payload['exit_code']`. Real scheduled-task payloads never send that field — only status of skipped/processed/failed — so `ok_count` and `server_error_count` stayed at 0 for every processed or failed run, breaking the Scheduled Tasks page's ok/failed chart and Processed/Failed columns.

Branches directly on `payload['status']` instead, matching how `applyJobStatus()` already handles job-attempt/queued-job payloads.