### PR TITLE
feat: add CLI commands to create teams, invite members, and create projects

### DIFF
--- a/app/Actions/Projects/CreateProject.php
+++ b/app/Actions/Projects/CreateProject.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Actions\Projects;
+
+use App\Models\Project;
+use App\Models\Team;
+use Illuminate\Support\Str;
+
+class CreateProject
+{
+    /**
+     * Create a project with its default email integration and default alert rules.
+     */
+    public function handle(Team $team, string $name, ?string $url, string $alertEmail): Project
+    {
+        $project = $team->projects()->create([
+            'name' => $name,
+            'url' => $url,
+            'api_token' => Str::random(32),
+            'uptime_check_interval' => 60,
+        ]);
+
+        $integration = $project->integrations()->create([
+            'name' => 'Default Email',
+            'type' => 'email',
+            'data' => ['email' => $alertEmail],
+            'is_enabled' => true,
+        ]);
+
+        foreach ($this->defaultAlertRules() as $ruleData) {
+            $rule = $project->alertRules()->create($ruleData + ['is_enabled' => true]);
+            $rule->integrations()->attach($integration->id);
+        }
+
+        return $project;
+    }
+
+    /**
+     * @return array<int, array{name: string, event_type: string, settings: array<string, mixed>}>
+     */
+    protected function defaultAlertRules(): array
+    {
+        return [
+            [
+                'name' => 'Critical Exceptions',
+                'event_type' => 'new_exception',
+                'settings' => ['frequency' => 'immediate'],
+            ],
+            [
+                'name' => 'Site DOWN Alert',
+                'event_type' => 'uptime_down',
+                'settings' => ['frequency' => 'immediate'],
+            ],
+            [
+                'name' => 'Error Spike Detected',
+                'event_type' => 'error_spike',
+                'settings' => ['threshold' => 50, 'period' => 1],
+            ],
+            [
+                'name' => 'Background Job Failed',
+                'event_type' => 'heartbeat_failed',
+                'settings' => ['frequency' => 'immediate'],
+            ],
+        ];
+    }
+}

--- a/app/Actions/Teams/AcceptTeamInvitation.php
+++ b/app/Actions/Teams/AcceptTeamInvitation.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Actions\Teams;
+
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class AcceptTeamInvitation
+{
+    /**
+     * Add the user to the invitation's team and mark the invitation accepted.
+     */
+    public function handle(User $user, TeamInvitation $invitation): void
+    {
+        DB::transaction(function () use ($user, $invitation) {
+            $team = $invitation->team;
+
+            $team->memberships()->firstOrCreate(
+                ['user_id' => $user->id],
+                ['role' => $invitation->role],
+            );
+
+            $invitation->update(['accepted_at' => now()]);
+
+            $user->switchTeam($team);
+        });
+    }
+}

--- a/app/Actions/Teams/InviteMember.php
+++ b/app/Actions/Teams/InviteMember.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Actions\Teams;
+
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use App\Notifications\Teams\TeamInvitation as TeamInvitationNotification;
+use Illuminate\Support\Facades\Notification;
+
+class InviteMember
+{
+    /**
+     * Create a team invitation and notify the invitee by email.
+     */
+    public function handle(Team $team, User $invitedBy, string $email, TeamRole $role, bool $notify = true): TeamInvitation
+    {
+        $invitation = $team->invitations()->create([
+            'email' => $email,
+            'role' => $role,
+            'invited_by' => $invitedBy->id,
+            'expires_at' => now()->addDays(3),
+        ]);
+
+        if ($notify) {
+            Notification::route('mail', $invitation->email)
+                ->notify(new TeamInvitationNotification($invitation));
+        }
+
+        return $invitation;
+    }
+}

--- a/app/Concerns/ResolvesConsoleIdentifiers.php
+++ b/app/Concerns/ResolvesConsoleIdentifiers.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Concerns;
+
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * Look up models from a CLI-friendly identifier (id, email or slug).
+ */
+trait ResolvesConsoleIdentifiers
+{
+    protected function findUserByIdOrEmail(string $identifier): ?User
+    {
+        return User::where(function ($query) use ($identifier) {
+            if (ctype_digit($identifier)) {
+                $query->orWhere('id', $identifier);
+            }
+
+            $query->orWhere('email', $identifier);
+        })->first();
+    }
+
+    protected function findTeamByIdOrSlug(string $identifier): ?Team
+    {
+        return Team::where(function ($query) use ($identifier) {
+            if (ctype_digit($identifier)) {
+                $query->orWhere('id', $identifier);
+            }
+
+            $query->orWhere('slug', $identifier);
+        })->first();
+    }
+}

--- a/app/Console/Commands/CreateProjectCommand.php
+++ b/app/Console/Commands/CreateProjectCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\Projects\CreateProject;
+use App\Concerns\ResolvesConsoleIdentifiers;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Validator;
+
+class CreateProjectCommand extends Command
+{
+    use ResolvesConsoleIdentifiers;
+
+    protected $signature = 'laraowl:projects:create
+                            {team : Team ID or slug}
+                            {name : The project name}
+                            {--url= : The project URL, used for uptime checks}
+                            {--email= : Default alert email (defaults to the team owner\'s email)}';
+
+    protected $description = 'Create a project (application) with its default alert rules, mirroring the "New project" web flow';
+
+    public function handle(CreateProject $createProject): int
+    {
+        $team = $this->findTeamByIdOrSlug((string) $this->argument('team'));
+
+        if (! $team) {
+            $this->error("Team [{$this->argument('team')}] not found.");
+
+            return self::FAILURE;
+        }
+
+        $alertEmail = $this->option('email') ?? $team->owner()?->email;
+
+        if (! $alertEmail) {
+            $this->error("Team [{$team->slug}] has no owner; pass --email to set the default alert address.");
+
+            return self::FAILURE;
+        }
+
+        $validator = Validator::make(
+            ['name' => $this->argument('name'), 'url' => $this->option('url'), 'email' => $alertEmail],
+            [
+                'name' => ['required', 'string', 'max:255'],
+                'url' => ['nullable', 'url', 'max:255'],
+                'email' => ['required', 'email'],
+            ],
+        );
+
+        if ($validator->fails()) {
+            foreach ($validator->errors()->all() as $message) {
+                $this->error($message);
+            }
+
+            return self::FAILURE;
+        }
+
+        $data = $validator->validated();
+
+        $project = $createProject->handle($team, $data['name'], $data['url'] ?? null, $data['email']);
+
+        $this->info("Project [{$project->name}] created (slug: {$project->slug}) in team [{$team->slug}].");
+        $this->line("Default alert email: {$data['email']}");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/CreateTeamCommand.php
+++ b/app/Console/Commands/CreateTeamCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\Teams\CreateTeam;
+use App\Concerns\ResolvesConsoleIdentifiers;
+use App\Http\Requests\Teams\SaveTeamRequest;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Validator;
+
+class CreateTeamCommand extends Command
+{
+    use ResolvesConsoleIdentifiers;
+
+    protected $signature = 'laraowl:teams:create
+                            {name : The team name}
+                            {owner : Owner user ID or email}
+                            {--personal : Mark the team as the owner\'s personal team}';
+
+    protected $description = 'Create a team and assign an owner, mirroring the "New team" web flow';
+
+    public function handle(CreateTeam $createTeam): int
+    {
+        $owner = $this->findUserByIdOrEmail((string) $this->argument('owner'));
+
+        if (! $owner) {
+            $this->error("User [{$this->argument('owner')}] not found.");
+
+            return self::FAILURE;
+        }
+
+        $validator = Validator::make(
+            ['name' => $this->argument('name')],
+            (new SaveTeamRequest)->rules(),
+        );
+
+        if ($validator->fails()) {
+            foreach ($validator->errors()->all() as $message) {
+                $this->error($message);
+            }
+
+            return self::FAILURE;
+        }
+
+        $team = $createTeam->handle($owner, $validator->validated()['name'], (bool) $this->option('personal'));
+
+        $this->info("Team [{$team->name}] created (slug: {$team->slug}).");
+        $this->line("Owner: {$owner->email}");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/InviteTeamMemberCommand.php
+++ b/app/Console/Commands/InviteTeamMemberCommand.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\Teams\AcceptTeamInvitation;
+use App\Actions\Teams\InviteMember;
+use App\Concerns\ResolvesConsoleIdentifiers;
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use App\Rules\UniqueTeamInvitation;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+
+class InviteTeamMemberCommand extends Command
+{
+    use ResolvesConsoleIdentifiers;
+
+    protected $signature = 'laraowl:teams:invite
+                            {team : Team ID or slug}
+                            {email : Email address to invite}
+                            {--role=member : Role to assign (member or admin)}
+                            {--by= : Inviter user ID or email (defaults to the team owner)}
+                            {--accept : Immediately join an existing user to the team instead of waiting for the invite email to be accepted}
+                            {--no-notify : Skip sending the invitation email}';
+
+    protected $description = 'Invite a user to a team, mirroring the team settings "invite" web flow';
+
+    public function handle(InviteMember $inviteMember, AcceptTeamInvitation $acceptTeamInvitation): int
+    {
+        $team = $this->findTeamByIdOrSlug((string) $this->argument('team'));
+
+        if (! $team) {
+            $this->error("Team [{$this->argument('team')}] not found.");
+
+            return self::FAILURE;
+        }
+
+        $invitedBy = $this->resolveInviter($team);
+
+        if (! $invitedBy) {
+            $this->error("Could not determine an inviter: team [{$team->slug}] has no owner and --by was not given.");
+
+            return self::FAILURE;
+        }
+
+        $validator = Validator::make(
+            ['email' => $this->argument('email'), 'role' => $this->option('role')],
+            [
+                'email' => ['required', 'string', 'email', 'max:255', new UniqueTeamInvitation($team)],
+                'role' => ['required', 'string', Rule::enum(TeamRole::class)],
+            ],
+        );
+
+        if ($validator->fails()) {
+            foreach ($validator->errors()->all() as $message) {
+                $this->error($message);
+            }
+
+            return self::FAILURE;
+        }
+
+        $data = $validator->validated();
+
+        $invitation = $inviteMember->handle(
+            $team,
+            $invitedBy,
+            $data['email'],
+            TeamRole::from($data['role']),
+            notify: ! $this->option('no-notify'),
+        );
+
+        $this->info("Invitation sent to [{$invitation->email}] for team [{$team->slug}] as {$invitation->role->label()}.");
+
+        if ($this->option('accept')) {
+            $this->acceptImmediately($invitation, $acceptTeamInvitation);
+        }
+
+        return self::SUCCESS;
+    }
+
+    protected function resolveInviter(Team $team): ?User
+    {
+        if ($identifier = $this->option('by')) {
+            return $this->findUserByIdOrEmail((string) $identifier);
+        }
+
+        return $team->owner();
+    }
+
+    protected function acceptImmediately(TeamInvitation $invitation, AcceptTeamInvitation $acceptTeamInvitation): void
+    {
+        $user = User::where('email', $invitation->email)->first();
+
+        if (! $user) {
+            $this->warn("No existing user with email [{$invitation->email}]; invitation left pending until they register and accept it.");
+
+            return;
+        }
+
+        $acceptTeamInvitation->handle($user, $invitation);
+
+        $this->info("User [{$user->email}] joined the team immediately (--accept).");
+    }
+}

--- a/app/Console/Commands/IssueMcpToken.php
+++ b/app/Console/Commands/IssueMcpToken.php
@@ -2,11 +2,13 @@
 
 namespace App\Console\Commands;
 
-use App\Models\User;
+use App\Concerns\ResolvesConsoleIdentifiers;
 use Illuminate\Console\Command;
 
 class IssueMcpToken extends Command
 {
+    use ResolvesConsoleIdentifiers;
+
     protected $signature = 'laraowl:mcp-token {user : User id or email} {--name=mcp : Token name}';
 
     protected $description = 'Issue a Sanctum personal access token for MCP access';
@@ -15,9 +17,7 @@ class IssueMcpToken extends Command
     {
         $identifier = (string) $this->argument('user');
 
-        $user = User::where('id', $identifier)
-            ->orWhere('email', $identifier)
-            ->first();
+        $user = $this->findUserByIdOrEmail($identifier);
 
         if (! $user) {
             $this->error("User [{$identifier}] not found.");

--- a/app/Http/Controllers/Projects/ProjectController.php
+++ b/app/Http/Controllers/Projects/ProjectController.php
@@ -2,12 +2,12 @@
 
 namespace App\Http\Controllers\Projects;
 
+use App\Actions\Projects\CreateProject;
 use App\Http\Controllers\Controller;
 use App\Models\Project;
 use App\Models\Team;
 use App\Services\CloudflareService;
 use Illuminate\Http\Request;
-use Illuminate\Support\Str;
 
 class ProjectController extends Controller
 {
@@ -96,7 +96,7 @@ class ProjectController extends Controller
         }
     }
 
-    public function store(Request $request, Team $current_team)
+    public function store(Request $request, Team $current_team, CreateProject $createProject)
     {
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
@@ -104,52 +104,10 @@ class ProjectController extends Controller
             'logo' => ['nullable', 'image', 'max:2048'],
         ]);
 
-        $project = $current_team->projects()->create([
-            'name' => $request->name,
-            'url' => $request->url,
-            'api_token' => Str::random(32),
-            'uptime_check_interval' => 60,
-        ]);
+        $project = $createProject->handle($current_team, $request->name, $request->url, $request->user()->email);
 
         if ($request->hasFile('logo')) {
             $project->addMediaFromRequest('logo')->toMediaCollection('logo');
-        }
-
-        // Create Default Email Integration
-        $integration = $project->integrations()->create([
-            'name' => 'Default Email',
-            'type' => 'email',
-            'data' => ['email' => $request->user()->email],
-            'is_enabled' => true,
-        ]);
-
-        // Create Default Alert Rules
-        $rules = [
-            [
-                'name' => 'Critical Exceptions',
-                'event_type' => 'new_exception',
-                'settings' => ['frequency' => 'immediate'],
-            ],
-            [
-                'name' => 'Site DOWN Alert',
-                'event_type' => 'uptime_down',
-                'settings' => ['frequency' => 'immediate'],
-            ],
-            [
-                'name' => 'Error Spike Detected',
-                'event_type' => 'error_spike',
-                'settings' => ['threshold' => 50, 'period' => 1], // 50 errors in 1 minute
-            ],
-            [
-                'name' => 'Background Job Failed',
-                'event_type' => 'heartbeat_failed',
-                'settings' => ['frequency' => 'immediate'],
-            ],
-        ];
-
-        foreach ($rules as $ruleData) {
-            $rule = $project->alertRules()->create($ruleData + ['is_enabled' => true]);
-            $rule->integrations()->attach($integration->id);
         }
 
         return redirect()->route('dashboard', [

--- a/app/Http/Controllers/Teams/TeamInvitationController.php
+++ b/app/Http/Controllers/Teams/TeamInvitationController.php
@@ -2,17 +2,16 @@
 
 namespace App\Http\Controllers\Teams;
 
+use App\Actions\Teams\AcceptTeamInvitation as AcceptTeamInvitationAction;
+use App\Actions\Teams\InviteMember;
 use App\Enums\TeamRole;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Teams\AcceptTeamInvitationRequest;
 use App\Http\Requests\Teams\CreateTeamInvitationRequest;
 use App\Models\Team;
 use App\Models\TeamInvitation;
-use App\Notifications\Teams\TeamInvitation as TeamInvitationNotification;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Facades\Notification;
 use Inertia\Inertia;
 
 class TeamInvitationController extends Controller
@@ -20,19 +19,16 @@ class TeamInvitationController extends Controller
     /**
      * Store a newly created invitation.
      */
-    public function store(CreateTeamInvitationRequest $request, Team $team): RedirectResponse
+    public function store(CreateTeamInvitationRequest $request, Team $team, InviteMember $inviteMember): RedirectResponse
     {
         Gate::authorize('inviteMember', $team);
 
-        $invitation = $team->invitations()->create([
-            'email' => $request->validated('email'),
-            'role' => TeamRole::from($request->validated('role')),
-            'invited_by' => $request->user()->id,
-            'expires_at' => now()->addDays(3),
-        ]);
-
-        Notification::route('mail', $invitation->email)
-            ->notify(new TeamInvitationNotification($invitation));
+        $inviteMember->handle(
+            $team,
+            $request->user(),
+            $request->validated('email'),
+            TeamRole::from($request->validated('role')),
+        );
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Invitation sent.')]);
 
@@ -58,24 +54,9 @@ class TeamInvitationController extends Controller
     /**
      * Accept the invitation.
      */
-    public function accept(AcceptTeamInvitationRequest $request, TeamInvitation $invitation): RedirectResponse
+    public function accept(AcceptTeamInvitationRequest $request, TeamInvitation $invitation, AcceptTeamInvitationAction $acceptTeamInvitation): RedirectResponse
     {
-        $user = $request->user();
-
-        DB::transaction(function () use ($user, $invitation) {
-            $team = $invitation->team;
-
-            $membership = $team->memberships()->firstOrCreate(
-                ['user_id' => $user->id],
-                ['role' => $invitation->role],
-            );
-
-            $wasRecentlyCreated = $membership->wasRecentlyCreated;
-
-            $invitation->update(['accepted_at' => now()]);
-
-            $user->switchTeam($team);
-        });
+        $acceptTeamInvitation->handle($request->user(), $invitation);
 
         return redirect('/dashboard');
     }

--- a/tests/Feature/Console/CreateProjectCommandTest.php
+++ b/tests/Feature/Console/CreateProjectCommandTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Models\Project;
+use App\Models\Team;
+use App\Models\User;
+
+test('a project is created with the team owner as default alert email', function () {
+    $owner = User::factory()->create(['email' => 'owner@example.com']);
+    $team = Team::factory()->create();
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $this->artisan('laraowl:projects:create', [
+        'team' => $team->slug,
+        'name' => 'My App',
+        '--url' => 'https://example.com',
+    ])->assertExitCode(0);
+
+    $project = Project::where('name', 'My App')->firstOrFail();
+
+    expect($project->team_id)->toBe($team->id)
+        ->and($project->url)->toBe('https://example.com')
+        ->and($project->api_token)->not->toBeNull()
+        ->and($project->integrations)->toHaveCount(1)
+        ->and($project->integrations->first()->data['email'])->toBe('owner@example.com')
+        ->and($project->alertRules)->toHaveCount(4);
+});
+
+test('the default alert email can be overridden with --email', function () {
+    $owner = User::factory()->create();
+    $team = Team::factory()->create();
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $this->artisan('laraowl:projects:create', [
+        'team' => $team->slug,
+        'name' => 'My App',
+        '--email' => 'alerts@example.com',
+    ])->assertExitCode(0);
+
+    $project = Project::where('name', 'My App')->firstOrFail();
+
+    expect($project->integrations->first()->data['email'])->toBe('alerts@example.com');
+});
+
+test('project creation fails for an unknown team', function () {
+    $this->artisan('laraowl:projects:create', ['team' => 'missing-team', 'name' => 'My App'])
+        ->assertExitCode(1);
+});
+
+test('project creation fails when the team has no owner and no --email is given', function () {
+    $team = Team::factory()->create();
+
+    $this->artisan('laraowl:projects:create', ['team' => $team->slug, 'name' => 'My App'])
+        ->assertExitCode(1);
+
+    $this->assertDatabaseMissing('projects', ['name' => 'My App']);
+});

--- a/tests/Feature/Console/CreateTeamCommandTest.php
+++ b/tests/Feature/Console/CreateTeamCommandTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Enums\TeamRole;
 use App\Models\Team;
 use App\Models\User;
 

--- a/tests/Feature/Console/CreateTeamCommandTest.php
+++ b/tests/Feature/Console/CreateTeamCommandTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\User;
+
+test('a team can be created for an existing owner by email', function () {
+    $owner = User::factory()->create(['email' => 'owner@example.com']);
+
+    $this->artisan('laraowl:teams:create', ['name' => 'Acme Inc', 'owner' => 'owner@example.com'])
+        ->assertExitCode(0);
+
+    $team = Team::where('name', 'Acme Inc')->firstOrFail();
+
+    expect($team->is_personal)->toBeFalse()
+        ->and($owner->fresh()->ownsTeam($team))->toBeTrue()
+        ->and($owner->fresh()->current_team_id)->toBe($team->id);
+});
+
+test('a team can be created for an existing owner by id', function () {
+    $owner = User::factory()->create();
+
+    $this->artisan('laraowl:teams:create', ['name' => 'Acme Inc', 'owner' => (string) $owner->id])
+        ->assertExitCode(0);
+
+    $this->assertDatabaseHas('teams', ['name' => 'Acme Inc']);
+});
+
+test('a team can be marked personal', function () {
+    $owner = User::factory()->create();
+
+    $this->artisan('laraowl:teams:create', [
+        'name' => 'Solo Team',
+        'owner' => $owner->email,
+        '--personal' => true,
+    ])->assertExitCode(0);
+
+    $this->assertDatabaseHas('teams', ['name' => 'Solo Team', 'is_personal' => true]);
+});
+
+test('team creation fails for an unknown owner', function () {
+    $this->artisan('laraowl:teams:create', ['name' => 'Acme Inc', 'owner' => 'missing@example.com'])
+        ->assertExitCode(1);
+
+    $this->assertDatabaseMissing('teams', ['name' => 'Acme Inc']);
+});
+
+test('team creation fails for a reserved name', function () {
+    $owner = User::factory()->create();
+
+    $this->artisan('laraowl:teams:create', ['name' => 'Settings', 'owner' => $owner->email])
+        ->assertExitCode(1);
+
+    $this->assertDatabaseMissing('teams', ['name' => 'Settings']);
+});

--- a/tests/Feature/Console/InviteTeamMemberCommandTest.php
+++ b/tests/Feature/Console/InviteTeamMemberCommandTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Illuminate\Support\Facades\Notification;
+
+test('a member can be invited and defaults to the team owner as inviter', function () {
+    Notification::fake();
+
+    $owner = User::factory()->create();
+    $team = Team::factory()->create();
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $this->artisan('laraowl:teams:invite', [
+        'team' => $team->slug,
+        'email' => 'invited@example.com',
+    ])->assertExitCode(0);
+
+    $this->assertDatabaseHas('team_invitations', [
+        'team_id' => $team->id,
+        'email' => 'invited@example.com',
+        'role' => TeamRole::Member->value,
+        'invited_by' => $owner->id,
+    ]);
+
+    Notification::assertSentOnDemand(\App\Notifications\Teams\TeamInvitation::class);
+});
+
+test('invitation email can be skipped with --no-notify', function () {
+    Notification::fake();
+
+    $owner = User::factory()->create();
+    $team = Team::factory()->create();
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $this->artisan('laraowl:teams:invite', [
+        'team' => $team->slug,
+        'email' => 'invited@example.com',
+        '--no-notify' => true,
+    ])->assertExitCode(0);
+
+    Notification::assertNothingSent();
+});
+
+test('an explicit inviter can be given via --by', function () {
+    Notification::fake();
+
+    $owner = User::factory()->create();
+    $admin = User::factory()->create();
+    $team = Team::factory()->create();
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    $team->members()->attach($admin, ['role' => TeamRole::Admin->value]);
+
+    $this->artisan('laraowl:teams:invite', [
+        'team' => $team->slug,
+        'email' => 'invited@example.com',
+        '--by' => $admin->email,
+    ])->assertExitCode(0);
+
+    $this->assertDatabaseHas('team_invitations', [
+        'team_id' => $team->id,
+        'invited_by' => $admin->id,
+    ]);
+});
+
+test('existing members cannot be invited again', function () {
+    Notification::fake();
+
+    $owner = User::factory()->create();
+    $member = User::factory()->create(['email' => 'member@example.com']);
+    $team = Team::factory()->create();
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    $this->artisan('laraowl:teams:invite', [
+        'team' => $team->slug,
+        'email' => 'member@example.com',
+    ])->assertExitCode(1);
+
+    $this->assertDatabaseMissing('team_invitations', ['email' => 'member@example.com']);
+});
+
+test('--accept immediately joins an existing user to the team', function () {
+    Notification::fake();
+
+    $owner = User::factory()->create();
+    $invitee = User::factory()->create(['email' => 'invited@example.com']);
+    $team = Team::factory()->create();
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $this->artisan('laraowl:teams:invite', [
+        'team' => $team->slug,
+        'email' => 'invited@example.com',
+        '--accept' => true,
+    ])->assertExitCode(0);
+
+    expect($invitee->fresh()->belongsToTeam($team))->toBeTrue();
+
+    $invitation = TeamInvitation::where('email', 'invited@example.com')->firstOrFail();
+    expect($invitation->accepted_at)->not->toBeNull();
+});
+
+test('--accept leaves the invitation pending when no matching user exists yet', function () {
+    Notification::fake();
+
+    $owner = User::factory()->create();
+    $team = Team::factory()->create();
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $this->artisan('laraowl:teams:invite', [
+        'team' => $team->slug,
+        'email' => 'not-yet-registered@example.com',
+        '--accept' => true,
+    ])->assertExitCode(0);
+
+    $invitation = TeamInvitation::where('email', 'not-yet-registered@example.com')->firstOrFail();
+    expect($invitation->accepted_at)->toBeNull();
+});

--- a/tests/Feature/Console/InviteTeamMemberCommandTest.php
+++ b/tests/Feature/Console/InviteTeamMemberCommandTest.php
@@ -4,6 +4,7 @@ use App\Enums\TeamRole;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
+use App\Notifications\Teams\TeamInvitation as TeamInvitationNotification;
 use Illuminate\Support\Facades\Notification;
 
 test('a member can be invited and defaults to the team owner as inviter', function () {
@@ -25,7 +26,7 @@ test('a member can be invited and defaults to the team owner as inviter', functi
         'invited_by' => $owner->id,
     ]);
 
-    Notification::assertSentOnDemand(\App\Notifications\Teams\TeamInvitation::class);
+    Notification::assertSentOnDemand(TeamInvitationNotification::class);
 });
 
 test('invitation email can be skipped with --no-notify', function () {


### PR DESCRIPTION
Adds Artisan commands mirroring the web onboarding flow (create team → invite member → create project), for scripted provisioning without going through the UI:

- `laraowl:teams:create {name} {owner} [--personal]`
- `laraowl:teams:invite {team} {email} [--role] [--by] [--accept] [--no-notify]`
- `laraowl:projects:create {team} {name} [--url] [--email]`

The invitation and project-creation logic that used to live only in `TeamInvitationController` and `ProjectController` was extracted into reusable actions (`App\Actions\Teams\InviteMember`, `AcceptTeamInvitation`, `App\Actions\Projects\CreateProject`), following the existing `CreateTeam` action pattern, so the web and CLI paths stay in sync and the controllers now delegate to them.

Also fixes a latent bug in the existing `laraowl:mcp-token` command (now sharing the new `App\Concerns\ResolvesConsoleIdentifiers` trait): comparing a non-numeric identifier against the bigint `id` column raised a Postgres type error instead of falling through to the email lookup.

CI (Pint, Pest, ESLint, Prettier, TypeScript) is green on this branch: https://github.com/solis-eduardo/laraowl/pull/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)