### PR TITLE
feat: show sidebar toggle button on desktop with shortcut tooltip

### DIFF
--- a/resources/js/components/app-sidebar-header.tsx
+++ b/resources/js/components/app-sidebar-header.tsx
@@ -2,6 +2,11 @@ import { usePage } from '@inertiajs/react';
 import { Breadcrumbs } from '@/components/breadcrumbs';
 import { TimeFilter } from '@/components/time-filter';
 import { SidebarTrigger } from '@/components/ui/sidebar';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
 import type { BreadcrumbItem as BreadcrumbItemType } from '@/types';
 
 export function AppSidebarHeader({
@@ -18,7 +23,14 @@ export function AppSidebarHeader({
     return (
         <header className="sticky top-0 z-50 flex h-16 shrink-0 items-center justify-between border-b border-border bg-background/80 px-6 backdrop-blur-md transition-all md:px-6">
             <div className="flex items-center gap-4">
-                <SidebarTrigger className="-ml-1 md:hidden" />
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <SidebarTrigger className="-ml-1" />
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" align="start">
+                        Toggle Sidebar (Ctrl/⌘ + B)
+                    </TooltipContent>
+                </Tooltip>
                 <Breadcrumbs breadcrumbs={breadcrumbs} />
             </div>
             <div className="flex items-center gap-4">


### PR DESCRIPTION
## Summary
- The `SidebarTrigger` button was hidden on desktop (`md:hidden`), leaving `Ctrl/Cmd+B` as the only way to collapse the sidebar there.
- Show the button on all breakpoints and add a tooltip documenting the keyboard shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)