### PR TITLE
refactor: use Collapsible primitive for record Headers/Payload cards

### DIFF
--- a/resources/js/pages/projects/records/show.tsx
+++ b/resources/js/pages/projects/records/show.tsx
@@ -14,6 +14,11 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
+import {
+    Collapsible,
+    CollapsibleContent,
+    CollapsibleTrigger,
+} from '@/components/ui/collapsible';
 import AppLayout from '@/layouts/app-layout';
 
 export default function RecordShow({
@@ -341,52 +346,60 @@ export default function RecordShow({
 
                 {/* Headers Card */}
                 <Card className="border-border bg-card shadow-2xl">
-                    <div
-                        className="flex cursor-pointer items-center justify-between p-4 transition-colors hover:bg-muted/30"
-                        onClick={() => setExpandedHeaders(!expandedHeaders)}
+                    <Collapsible
+                        open={expandedHeaders}
+                        onOpenChange={setExpandedHeaders}
                     >
-                        <h3 className="text-xs font-bold text-foreground uppercase">
-                            Headers
-                        </h3>
-                        <div className="flex h-5 w-5 items-center justify-center rounded bg-muted">
-                            {expandedHeaders ? (
-                                <ChevronDown className="h-3 w-3" />
-                            ) : (
-                                <ChevronRight className="h-3 w-3" />
-                            )}
-                        </div>
-                    </div>
-                    {expandedHeaders && (
-                        <div className="border-t border-border p-6 text-xs">
-                            {(() => {
-                                let headersObj = payload.headers || {};
+                        <CollapsibleTrigger asChild>
+                            <div className="flex cursor-pointer items-center justify-between p-4 transition-colors hover:bg-muted/30">
+                                <h3 className="text-xs font-bold text-foreground uppercase">
+                                    Headers
+                                </h3>
+                                <div className="flex h-5 w-5 items-center justify-center rounded bg-muted">
+                                    {expandedHeaders ? (
+                                        <ChevronDown className="h-3 w-3" />
+                                    ) : (
+                                        <ChevronRight className="h-3 w-3" />
+                                    )}
+                                </div>
+                            </div>
+                        </CollapsibleTrigger>
+                        <CollapsibleContent>
+                            <div className="border-t border-border p-6 text-xs">
+                                {(() => {
+                                    let headersObj = payload.headers || {};
 
-                                if (typeof headersObj === 'string') {
-                                    try {
-                                        headersObj = JSON.parse(headersObj);
-                                    } catch {
-                                        // ignore
+                                    if (typeof headersObj === 'string') {
+                                        try {
+                                            headersObj = JSON.parse(headersObj);
+                                        } catch {
+                                            // ignore
+                                        }
                                     }
-                                }
 
-                                return (
-                                    <SyntaxHighlighter
-                                        language="json"
-                                        style={vscDarkPlus}
-                                        customStyle={{
-                                            margin: 0,
-                                            borderRadius: '0.5rem',
-                                            border: '1px solid hsl(var(--border))',
-                                        }}
-                                        wrapLines={true}
-                                        wrapLongLines={true}
-                                    >
-                                        {JSON.stringify(headersObj, null, 4)}
-                                    </SyntaxHighlighter>
-                                );
-                            })()}
-                        </div>
-                    )}
+                                    return (
+                                        <SyntaxHighlighter
+                                            language="json"
+                                            style={vscDarkPlus}
+                                            customStyle={{
+                                                margin: 0,
+                                                borderRadius: '0.5rem',
+                                                border: '1px solid hsl(var(--border))',
+                                            }}
+                                            wrapLines={true}
+                                            wrapLongLines={true}
+                                        >
+                                            {JSON.stringify(
+                                                headersObj,
+                                                null,
+                                                4,
+                                            )}
+                                        </SyntaxHighlighter>
+                                    );
+                                })()}
+                            </div>
+                        </CollapsibleContent>
+                    </Collapsible>
                 </Card>
 
                 {/* Request Payload Card */}
@@ -414,42 +427,44 @@ export default function RecordShow({
 
                     return (
                         <Card className="border-border bg-card shadow-2xl">
-                            <div
-                                className="flex cursor-pointer items-center justify-between p-4 transition-colors hover:bg-muted/30"
-                                onClick={() =>
-                                    setExpandedPayload(!expandedPayload)
-                                }
+                            <Collapsible
+                                open={expandedPayload}
+                                onOpenChange={setExpandedPayload}
                             >
-                                <h3 className="text-xs font-bold text-foreground uppercase">
-                                    Request Payload
-                                </h3>
-                                <div className="flex h-5 w-5 items-center justify-center rounded bg-muted">
-                                    {expandedPayload ? (
-                                        <ChevronDown className="h-3 w-3" />
-                                    ) : (
-                                        <ChevronRight className="h-3 w-3" />
-                                    )}
-                                </div>
-                            </div>
-                            {expandedPayload && (
-                                <div className="border-t border-border p-6 text-xs">
-                                    <SyntaxHighlighter
-                                        language="json"
-                                        style={vscDarkPlus}
-                                        customStyle={{
-                                            margin: 0,
-                                            borderRadius: '0.5rem',
-                                            border: '1px solid hsl(var(--border))',
-                                        }}
-                                        wrapLines={true}
-                                        wrapLongLines={true}
-                                    >
-                                        {typeof body === 'string'
-                                            ? body
-                                            : JSON.stringify(body, null, 4)}
-                                    </SyntaxHighlighter>
-                                </div>
-                            )}
+                                <CollapsibleTrigger asChild>
+                                    <div className="flex cursor-pointer items-center justify-between p-4 transition-colors hover:bg-muted/30">
+                                        <h3 className="text-xs font-bold text-foreground uppercase">
+                                            Request Payload
+                                        </h3>
+                                        <div className="flex h-5 w-5 items-center justify-center rounded bg-muted">
+                                            {expandedPayload ? (
+                                                <ChevronDown className="h-3 w-3" />
+                                            ) : (
+                                                <ChevronRight className="h-3 w-3" />
+                                            )}
+                                        </div>
+                                    </div>
+                                </CollapsibleTrigger>
+                                <CollapsibleContent>
+                                    <div className="border-t border-border p-6 text-xs">
+                                        <SyntaxHighlighter
+                                            language="json"
+                                            style={vscDarkPlus}
+                                            customStyle={{
+                                                margin: 0,
+                                                borderRadius: '0.5rem',
+                                                border: '1px solid hsl(var(--border))',
+                                            }}
+                                            wrapLines={true}
+                                            wrapLongLines={true}
+                                        >
+                                            {typeof body === 'string'
+                                                ? body
+                                                : JSON.stringify(body, null, 4)}
+                                        </SyntaxHighlighter>
+                                    </div>
+                                </CollapsibleContent>
+                            </Collapsible>
                         </Card>
                     );
                 })()}


### PR DESCRIPTION
## Problem

The "Headers" and "Request Payload" cards on the record detail page (`RecordShow`) each toggled visibility with their own `useState` boolean, an `onClick` on a plain `div`, and a conditional `{expanded && (...)}` render — the same pattern duplicated twice in the same file.

## Fix

Replaced both with the `Collapsible`/`CollapsibleTrigger`/`CollapsibleContent` primitives already present in `components/ui/collapsible.tsx` (a Radix wrapper that shipped with the project's initial scaffold but had no callers anywhere). The trigger keeps the exact same markup — title + chevron icon — via `CollapsibleTrigger asChild`, so no visual or behavioral change is intended.

## Testing

Verified manually against the running app: captured screenshots of both cards in the closed and open state before and after the change (same route, same record, same viewport) — pixel-identical. Also ran `tsc --noEmit`, ESLint, and Prettier on the changed file — all clean. No automated test added; this file has no existing test coverage and the change is a pure implementation swap with no behavior difference to assert against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)