### PR TITLE
refactor: consolidate ad-hoc icon rendering into shared Icon component

### DIFF
--- a/resources/js/components/appearance-tabs.tsx
+++ b/resources/js/components/appearance-tabs.tsx
@@ -1,6 +1,7 @@
 import type { LucideIcon } from 'lucide-react';
 import { Monitor, Moon, Sun } from 'lucide-react';
 import type { HTMLAttributes } from 'react';
+import { Icon } from '@/components/ui/icon';
 import type { Appearance } from '@/hooks/use-appearance';
 import { useAppearance } from '@/hooks/use-appearance';
 import { cn } from '@/lib/utils';
@@ -25,7 +26,7 @@ export default function AppearanceToggleTab({
             )}
             {...props}
         >
-            {tabs.map(({ value, icon: Icon, label }) => (
+            {tabs.map(({ value, icon, label }) => (
                 <button
                     key={value}
                     onClick={() => updateAppearance(value)}
@@ -36,7 +37,7 @@ export default function AppearanceToggleTab({
                             : 'text-neutral-500 hover:bg-neutral-200/60 hover:text-black dark:text-neutral-400 dark:hover:bg-neutral-700/60',
                     )}
                 >
-                    <Icon className="-ml-1 h-4 w-4" />
+                    <Icon iconNode={icon} className="-ml-1 h-4 w-4" />
                     <span className="ml-1.5 text-sm">{label}</span>
                 </button>
             ))}

--- a/resources/js/components/empty-state.tsx
+++ b/resources/js/components/empty-state.tsx
@@ -2,6 +2,7 @@ import { Link } from '@inertiajs/react';
 import type { LucideIcon } from 'lucide-react';
 import { Ghost } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Icon } from '@/components/ui/icon';
 
 interface EmptyStateProps {
     title: string;
@@ -16,7 +17,7 @@ interface EmptyStateProps {
 export function EmptyState({
     title,
     description,
-    icon: Icon = Ghost,
+    icon = Ghost,
     action,
 }: EmptyStateProps) {
     return (
@@ -24,7 +25,10 @@ export function EmptyState({
             <div className="relative mb-6">
                 <div className="absolute inset-0 rounded-full bg-muted blur-2xl" />
                 <div className="relative flex size-16 items-center justify-center rounded-2xl border border-border bg-muted shadow-2xl">
-                    <Icon className="size-8 text-muted-foreground" />
+                    <Icon
+                        iconNode={icon}
+                        className="size-8 text-muted-foreground"
+                    />
                 </div>
             </div>
             <h3 className="mb-2 text-xl font-bold tracking-tight text-foreground uppercase">

--- a/resources/js/pages/projects/firewall/traffic.tsx
+++ b/resources/js/pages/projects/firewall/traffic.tsx
@@ -14,6 +14,7 @@ import {
 import { AreaChart, Area, ResponsiveContainer } from 'recharts';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Icon } from '@/components/ui/icon';
 import AppLayout from '@/layouts/app-layout';
 import { ConnectCloudflare } from './components/connect-cloudflare';
 
@@ -36,7 +37,7 @@ const Sparkline = ({ data, color }: { data: number[]; color: string }) => (
 
 const StatCard = ({
     title,
-    icon: Icon,
+    icon,
     items,
     color = '#3b82f6',
     onBlock,
@@ -50,7 +51,7 @@ const StatCard = ({
     <Card className="overflow-hidden border-border bg-card shadow-2xl">
         <CardHeader className="border-b border-border/50 p-4">
             <CardTitle className="flex items-center gap-2 text-[10px] font-black tracking-widest text-muted-foreground uppercase">
-                <Icon className="size-3.5" />
+                <Icon iconNode={icon} className="size-3.5" />
                 {title}
             </CardTitle>
         </CardHeader>


### PR DESCRIPTION
## Problem

`appearance-tabs.tsx`, `empty-state.tsx`, and `firewall/traffic.tsx`'s `StatCard` each receive a Lucide icon component through a prop, rename it to `Icon` at the destructuring site (`icon: Icon`), and render it directly (`<Icon className=... />`) — the same small pattern independently written three times.

## Fix

Routes all three through `components/ui/icon.tsx` — a wrapper (`export function Icon({ iconNode, className })`) that shipped in the project's initial scaffold but had no callers anywhere in the codebase. Each site now keeps the prop as `icon` and renders `<Icon iconNode={icon} className=... />`. Behavior is unchanged: the wrapper renders the passed component when present and `null` otherwise, same as the inline version.

## Testing

Verified manually against the running app: screenshots of `/settings/appearance` (Light/Dark/System icons) and the Mail empty state before and after the change — pixel-identical. Couldn't get a live render of the `StatCard` case specifically (`firewall/traffic.tsx`) because none of the available test projects have Cloudflare connected, so that card never mounts; `tsc --noEmit`, ESLint, and Prettier are clean on it and the change is identical in shape to the other two confirmed cases. No automated test added — no existing coverage for these components and the change has no behavior to assert against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)