### PR TITLE
Add uptime monitoring switch

### DIFF
--- a/app/Console/Commands/CheckProjectUptime.php
+++ b/app/Console/Commands/CheckProjectUptime.php
@@ -37,7 +37,7 @@ class CheckProjectUptime extends Command
         $this->checkHeartbeats($alertService);
 
         // 3. Support sub-minute intervals (30s)
-        if (Project::where('uptime_check_interval', '<', 60)->whereNotNull('url')->exists()) {
+        if (Project::withUptimeMonitoring()->where('uptime_check_interval', '<', 60)->exists()) {
             $this->info('Waiting 30 seconds for next sub-minute check...');
             sleep(30);
             $this->performUptimeChecks($alertService);
@@ -48,7 +48,7 @@ class CheckProjectUptime extends Command
 
     protected function performUptimeChecks(AlertService $alertService)
     {
-        $projects = Project::whereNotNull('url')->get()->filter(function ($project) {
+        $projects = Project::withUptimeMonitoring()->get()->filter(function ($project) {
             if (is_null($project->last_uptime_check_at)) {
                 return true;
             }

--- a/app/Http/Controllers/Projects/ProjectController.php
+++ b/app/Http/Controllers/Projects/ProjectController.php
@@ -16,13 +16,17 @@ class ProjectController extends Controller
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'url' => ['nullable', 'url', 'max:255'],
-            'uptime_monitoring_enabled' => ['nullable', 'boolean'],
+            'uptime_monitoring_enabled' => ['sometimes', 'boolean'],
             'uptime_check_interval' => ['nullable', 'integer', 'min:30'],
             'retention_days' => ['nullable', 'integer', 'min:0', 'max:365'],
             'logo' => ['nullable', 'image', 'max:2048'],
         ]);
 
-        $monitoringEnabled = $request->boolean('uptime_monitoring_enabled');
+        // Keep the stored value when the field is omitted so a partial update
+        // can't silently switch monitoring off.
+        $monitoringEnabled = $request->missing('uptime_monitoring_enabled')
+            ? $project->uptime_monitoring_enabled
+            : $request->boolean('uptime_monitoring_enabled');
 
         $attributes = [
             'name' => $request->name,

--- a/app/Http/Controllers/Projects/ProjectController.php
+++ b/app/Http/Controllers/Projects/ProjectController.php
@@ -16,17 +16,30 @@ class ProjectController extends Controller
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'url' => ['nullable', 'url', 'max:255'],
+            'uptime_monitoring_enabled' => ['nullable', 'boolean'],
             'uptime_check_interval' => ['nullable', 'integer', 'min:30'],
             'retention_days' => ['nullable', 'integer', 'min:0', 'max:365'],
             'logo' => ['nullable', 'image', 'max:2048'],
         ]);
 
-        $project->update([
+        $monitoringEnabled = $request->boolean('uptime_monitoring_enabled');
+
+        $attributes = [
             'name' => $request->name,
             'url' => $request->url,
+            'uptime_monitoring_enabled' => $monitoringEnabled,
             'uptime_check_interval' => $request->uptime_check_interval ?? 60,
             'retention_days' => $request->retention_days ?? 7,
-        ]);
+        ];
+
+        // Clear the stale status so a disabled project no longer reads as
+        // "down" and re-enabling it can't fire a false recovery alert.
+        if (! $monitoringEnabled && $project->uptime_monitoring_enabled) {
+            $attributes['last_uptime_status'] = null;
+            $attributes['last_uptime_check_at'] = null;
+        }
+
+        $project->update($attributes);
 
         if ($request->hasFile('logo')) {
             $project->clearMediaCollection('logo');

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\GeneratesUniqueProjectSlugs;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -40,6 +41,7 @@ class Project extends Model implements HasMedia
         'slug',
         'api_token',
         'url',
+        'uptime_monitoring_enabled',
         'uptime_check_interval',
         'last_uptime_check_at',
         'last_uptime_status',
@@ -72,7 +74,24 @@ class Project extends Model implements HasMedia
     protected $casts = [
         'settings' => 'array',
         'last_uptime_check_at' => 'datetime',
+        'uptime_monitoring_enabled' => 'boolean',
     ];
+
+    /**
+     * Determine whether this project is eligible for uptime checks.
+     */
+    public function hasUptimeMonitoring(): bool
+    {
+        return $this->uptime_monitoring_enabled && filled($this->url);
+    }
+
+    /**
+     * Scope the query to projects that should be checked for uptime.
+     */
+    public function scopeWithUptimeMonitoring(Builder $query): Builder
+    {
+        return $query->where('uptime_monitoring_enabled', true)->whereNotNull('url');
+    }
 
     public function getRouteKeyName(): string
     {

--- a/app/Services/RecordService.php
+++ b/app/Services/RecordService.php
@@ -951,6 +951,18 @@ class RecordService
 
     public function getUptimeStats(Project $project, ?string $period = null, ?string $from = null, ?string $to = null): array
     {
+        if (! $project->hasUptimeMonitoring()) {
+            return [
+                'checks' => new LengthAwarePaginator([], 0, 50),
+                'uptime_stats' => [
+                    'uptime_percentage' => 0,
+                    'avg_response_time' => 0,
+                    'last_check' => null,
+                    'total_checks' => 0,
+                ],
+            ];
+        }
+
         $query = $project->uptimeChecks()
             ->orderBy('checked_at', 'desc');
 

--- a/database/factories/ProjectFactory.php
+++ b/database/factories/ProjectFactory.php
@@ -19,7 +19,18 @@ class ProjectFactory extends Factory
             'slug' => fn (array $attributes) => Str::slug($attributes['name']),
             'api_token' => Str::random(64),
             'url' => $this->faker->url(),
+            'uptime_monitoring_enabled' => true,
             'settings' => [],
         ];
+    }
+
+    /**
+     * Indicate that the project should not be checked for uptime.
+     */
+    public function withoutUptimeMonitoring(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'uptime_monitoring_enabled' => false,
+        ]);
     }
 }

--- a/database/migrations/2026_08_10_060346_add_uptime_monitoring_enabled_to_projects_table.php
+++ b/database/migrations/2026_08_10_060346_add_uptime_monitoring_enabled_to_projects_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->boolean('uptime_monitoring_enabled')->default(true)->after('url');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dropColumn('uptime_monitoring_enabled');
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -5081,9 +5081,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5099,9 +5096,6 @@
             "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -5119,9 +5113,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5137,9 +5128,6 @@
             "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -5157,9 +5145,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5175,9 +5160,6 @@
             "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5081,6 +5081,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5096,6 +5099,9 @@
             "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -5113,6 +5119,9 @@
             "cpu": [
                 "ppc64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5128,6 +5137,9 @@
             "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
             "cpu": [
                 "s390x"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -5145,6 +5157,9 @@
             "cpu": [
                 "x64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5160,6 +5175,9 @@
             "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -129,17 +129,23 @@ export function AppSidebar() {
         },
     ];
 
+    const uptimeEnabled = currentProject?.uptime_monitoring_enabled ?? true;
+
     const monitoringNavItems: NavItem[] = [
         {
             title: 'Users',
             href: withPeriod(`/${teamSlug}/${projectSlug}/users`),
             icon: Users,
         },
-        {
-            title: 'Uptime',
-            href: withPeriod(`/${teamSlug}/${projectSlug}/uptime`),
-            icon: Globe,
-        },
+        ...(uptimeEnabled
+            ? [
+                  {
+                      title: 'Uptime',
+                      href: withPeriod(`/${teamSlug}/${projectSlug}/uptime`),
+                      icon: Globe,
+                  },
+              ]
+            : []),
         {
             title: 'Logs',
             href: withPeriod(`/${teamSlug}/${projectSlug}/logs`),

--- a/resources/js/components/ui/switch.tsx
+++ b/resources/js/components/ui/switch.tsx
@@ -27,7 +27,7 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
         data-state={isChecked ? "checked" : "unchecked"}
         ref={ref}
         className={cn(
-          "inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-neutral-200 dark:data-[state=unchecked]:bg-neutral-800",
+          "inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-emerald-500 data-[state=unchecked]:bg-neutral-300 dark:data-[state=unchecked]:bg-neutral-700",
           className
         )}
         onClick={handleToggle}

--- a/resources/js/pages/dashboard/index.tsx
+++ b/resources/js/pages/dashboard/index.tsx
@@ -53,6 +53,8 @@ export default function Dashboard({
             to,
         });
 
+    const uptimeEnabled = currentProject?.uptime_monitoring_enabled ?? true;
+
     useLiveReload(currentProject?.id);
 
     return (
@@ -65,7 +67,13 @@ export default function Dashboard({
                     {/* Uptime Status */}
                     <Card className="relative overflow-hidden border-border bg-card shadow-2xl lg:col-span-4">
                         <div
-                            className={`absolute top-0 right-0 h-24 w-24 translate-x-8 -translate-y-8 rounded-full opacity-20 blur-3xl ${uptime_status?.current === 'up' ? 'bg-emerald-500' : 'bg-red-500'}`}
+                            className={`absolute top-0 right-0 h-24 w-24 translate-x-8 -translate-y-8 rounded-full opacity-20 blur-3xl ${
+                                !uptimeEnabled
+                                    ? 'bg-muted-foreground'
+                                    : uptime_status?.current === 'up'
+                                      ? 'bg-emerald-500'
+                                      : 'bg-red-500'
+                            }`}
                         />
                         <CardContent className="p-8">
                             <div className="mb-6 flex items-center justify-between">
@@ -74,30 +82,47 @@ export default function Dashboard({
                                 </div>
                                 <Badge
                                     className={`h-5 gap-1.5 border-none px-2 text-[9px] font-black uppercase ${
-                                        uptime_status?.current === 'up'
-                                            ? 'bg-emerald-500/10 text-emerald-500'
-                                            : uptime_status?.current === 'down'
-                                              ? 'bg-red-500/10 text-red-500'
-                                              : 'bg-muted text-muted-foreground'
+                                        !uptimeEnabled
+                                            ? 'bg-muted text-muted-foreground'
+                                            : uptime_status?.current === 'up'
+                                              ? 'bg-emerald-500/10 text-emerald-500'
+                                              : uptime_status?.current ===
+                                                  'down'
+                                                ? 'bg-red-500/10 text-red-500'
+                                                : 'bg-muted text-muted-foreground'
                                     }`}
                                 >
                                     <span
-                                        className={`size-1.5 rounded-full ${uptime_status?.current === 'up' ? 'animate-pulse bg-emerald-500' : 'bg-red-500'}`}
+                                        className={`size-1.5 rounded-full ${
+                                            !uptimeEnabled
+                                                ? 'bg-muted-foreground'
+                                                : uptime_status?.current ===
+                                                    'up'
+                                                  ? 'animate-pulse bg-emerald-500'
+                                                  : 'bg-red-500'
+                                        }`}
                                     />
-                                    {uptime_status?.current || 'Monitoring...'}
+                                    {!uptimeEnabled
+                                        ? 'Disabled'
+                                        : uptime_status?.current ||
+                                          'Monitoring...'}
                                 </Badge>
                             </div>
                             <div className="mb-2 text-3xl font-black tracking-tighter text-foreground">
-                                {uptime_status?.current === 'up'
-                                    ? 'All Systems Operational'
-                                    : uptime_status?.current === 'down'
-                                      ? 'Service Disruption'
-                                      : 'Awaiting Data'}
+                                {!uptimeEnabled
+                                    ? 'Monitoring Disabled'
+                                    : uptime_status?.current === 'up'
+                                      ? 'All Systems Operational'
+                                      : uptime_status?.current === 'down'
+                                        ? 'Service Disruption'
+                                        : 'Awaiting Data'}
                             </div>
                             <p className="text-[10px] font-medium tracking-tight text-muted-foreground uppercase">
-                                {uptime_status?.last_check
-                                    ? `Last check: ${new Date(uptime_status.last_check).toLocaleTimeString()}`
-                                    : 'Configuring monitor...'}
+                                {!uptimeEnabled
+                                    ? 'Enable uptime monitoring in project settings'
+                                    : uptime_status?.last_check
+                                      ? `Last check: ${new Date(uptime_status.last_check).toLocaleTimeString()}`
+                                      : 'Configuring monitor...'}
                             </p>
                         </CardContent>
                     </Card>

--- a/resources/js/pages/projects/settings/index.tsx
+++ b/resources/js/pages/projects/settings/index.tsx
@@ -51,6 +51,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
     Tooltip,
@@ -113,6 +114,7 @@ export default function ProjectSettings({
     const generalForm = useForm({
         name: project.name,
         url: project.url || '',
+        uptime_monitoring_enabled: project.uptime_monitoring_enabled ?? true,
         uptime_check_interval: project.uptime_check_interval || 60,
         retention_days: project.retention_days || 7,
         logo: null as File | null,
@@ -869,61 +871,88 @@ export default function ProjectSettings({
                                                         placeholder="https://example.com"
                                                     />
                                                 </div>
-                                                <div className="space-y-2">
+                                                <div className="flex items-center justify-between gap-4 rounded-xl border border-border bg-muted px-4 py-3">
                                                     <Label>
-                                                        Uptime Check Interval
+                                                        Uptime Monitoring
                                                     </Label>
-                                                    <Select
-                                                        value={String(
+                                                    <Switch
+                                                        checked={
                                                             generalForm.data
-                                                                .uptime_check_interval,
-                                                        )}
-                                                        onValueChange={(val) =>
+                                                                .uptime_monitoring_enabled
+                                                        }
+                                                        onCheckedChange={(
+                                                            checked,
+                                                        ) =>
                                                             generalForm.setData(
-                                                                'uptime_check_interval',
-                                                                parseInt(val),
+                                                                'uptime_monitoring_enabled',
+                                                                checked,
                                                             )
                                                         }
-                                                    >
-                                                        <SelectTrigger className="h-11 rounded-xl border-border bg-muted">
-                                                            <SelectValue placeholder="Select interval" />
-                                                        </SelectTrigger>
-                                                        <SelectContent className="border-border bg-popover">
-                                                            <SelectItem value="30">
-                                                                30 Seconds
-                                                            </SelectItem>
-                                                            <SelectItem value="60">
-                                                                1 Minute
-                                                                (Default)
-                                                            </SelectItem>
-                                                            <SelectItem value="120">
-                                                                2 Minutes
-                                                            </SelectItem>
-                                                            <SelectItem value="180">
-                                                                3 Minutes
-                                                            </SelectItem>
-                                                            <SelectItem value="300">
-                                                                5 Minutes
-                                                            </SelectItem>
-                                                            <SelectItem value="600">
-                                                                10 Minutes
-                                                            </SelectItem>
-                                                            <SelectItem value="900">
-                                                                15 Minutes
-                                                            </SelectItem>
-                                                            <SelectItem value="1800">
-                                                                30 Minutes
-                                                            </SelectItem>
-                                                            <SelectItem value="3600">
-                                                                1 Hour
-                                                            </SelectItem>
-                                                        </SelectContent>
-                                                    </Select>
-                                                    <p className="text-[10px] font-black tracking-widest text-muted-foreground uppercase opacity-50">
-                                                        Frequency of
-                                                        availability checks.
-                                                    </p>
+                                                    />
                                                 </div>
+                                                {generalForm.data
+                                                    .uptime_monitoring_enabled && (
+                                                    <div className="space-y-2">
+                                                        <Label>
+                                                            Uptime Check
+                                                            Interval
+                                                        </Label>
+                                                        <Select
+                                                            value={String(
+                                                                generalForm.data
+                                                                    .uptime_check_interval,
+                                                            )}
+                                                            onValueChange={(
+                                                                val,
+                                                            ) =>
+                                                                generalForm.setData(
+                                                                    'uptime_check_interval',
+                                                                    parseInt(
+                                                                        val,
+                                                                    ),
+                                                                )
+                                                            }
+                                                        >
+                                                            <SelectTrigger className="h-11 rounded-xl border-border bg-muted">
+                                                                <SelectValue placeholder="Select interval" />
+                                                            </SelectTrigger>
+                                                            <SelectContent className="border-border bg-popover">
+                                                                <SelectItem value="30">
+                                                                    30 Seconds
+                                                                </SelectItem>
+                                                                <SelectItem value="60">
+                                                                    1 Minute
+                                                                    (Default)
+                                                                </SelectItem>
+                                                                <SelectItem value="120">
+                                                                    2 Minutes
+                                                                </SelectItem>
+                                                                <SelectItem value="180">
+                                                                    3 Minutes
+                                                                </SelectItem>
+                                                                <SelectItem value="300">
+                                                                    5 Minutes
+                                                                </SelectItem>
+                                                                <SelectItem value="600">
+                                                                    10 Minutes
+                                                                </SelectItem>
+                                                                <SelectItem value="900">
+                                                                    15 Minutes
+                                                                </SelectItem>
+                                                                <SelectItem value="1800">
+                                                                    30 Minutes
+                                                                </SelectItem>
+                                                                <SelectItem value="3600">
+                                                                    1 Hour
+                                                                </SelectItem>
+                                                            </SelectContent>
+                                                        </Select>
+                                                        <p className="text-[10px] font-black tracking-widest text-muted-foreground uppercase opacity-50">
+                                                            Frequency of
+                                                            availability checks.
+                                                        </p>
+                                                    </div>
+                                                )}
 
                                                 <div className="space-y-2">
                                                     <Label>

--- a/resources/js/pages/projects/uptime/index.tsx
+++ b/resources/js/pages/projects/uptime/index.tsx
@@ -20,6 +20,27 @@ export default function UptimeIndex({ checks, uptime_stats, period }: any) {
 
     useLiveReload(currentProject?.id);
 
+    if (currentProject && !currentProject.uptime_monitoring_enabled) {
+        return (
+            <>
+                <Head title={`Uptime - ${currentProject?.name}`} />
+
+                <Card className="border-border bg-card p-12 shadow-2xl">
+                    <div className="flex flex-col items-center justify-center gap-4 text-center">
+                        <Globe className="size-12 text-muted-foreground/30" />
+                        <div className="text-2xl font-black tracking-tighter text-foreground">
+                            Uptime Monitoring Disabled
+                        </div>
+                        <p className="max-w-md text-[10px] font-black tracking-widest text-muted-foreground uppercase opacity-50">
+                            Enable it under the project's general settings to
+                            start checking availability again.
+                        </p>
+                    </div>
+                </Card>
+            </>
+        );
+    }
+
     return (
         <>
             <Head title={`Uptime - ${currentProject?.name}`} />

--- a/tests/Feature/CheckProjectUptimeTest.php
+++ b/tests/Feature/CheckProjectUptimeTest.php
@@ -74,6 +74,62 @@ test('it logs up when the check fails on the first try but succeeds on the retry
     expect($project->uptimeChecks->first()->status)->toBe('up');
 });
 
+test('it skips projects with uptime monitoring disabled', function () {
+    $team = Team::factory()->create();
+    $project = Project::factory()->create([
+        'team_id' => $team->id,
+        'url' => 'https://example.com',
+        'uptime_monitoring_enabled' => false,
+        'last_uptime_status' => null,
+    ]);
+
+    Http::fake([
+        '*' => Http::response('OK', 200),
+    ]);
+
+    $alertService = Mockery::mock(AlertService::class);
+    $alertService->shouldNotReceive('notifyUptimeDown');
+    $this->instance(AlertService::class, $alertService);
+
+    $this->artisan('projects:check-health')
+        ->assertExitCode(0);
+
+    Http::assertNothingSent();
+
+    $project->refresh();
+    expect($project->last_uptime_status)->toBeNull();
+    expect($project->last_uptime_check_at)->toBeNull();
+    expect($project->uptimeChecks)->toHaveCount(0);
+});
+
+test('it does not alert for a disabled project that was previously down', function () {
+    $team = Team::factory()->create();
+    $project = Project::factory()->create([
+        'team_id' => $team->id,
+        'url' => 'https://example.com',
+        'uptime_monitoring_enabled' => false,
+        'uptime_check_interval' => 30,
+        'last_uptime_status' => 'down',
+    ]);
+
+    Http::fake([
+        '*' => Http::response('OK', 200),
+    ]);
+
+    $alertService = Mockery::mock(AlertService::class);
+    $alertService->shouldNotReceive('notifyUptimeDown');
+    $this->instance(AlertService::class, $alertService);
+
+    $this->artisan('projects:check-health')
+        ->assertExitCode(0);
+
+    Http::assertNothingSent();
+
+    $project->refresh();
+    expect($project->last_uptime_status)->toBe('down');
+    expect($project->uptimeChecks)->toHaveCount(0);
+});
+
 test('it logs down and sends alert when all attempts fail', function () {
     $team = Team::factory()->create();
     $project = Project::factory()->create([

--- a/tests/Feature/ProjectUptimeMonitoringSettingTest.php
+++ b/tests/Feature/ProjectUptimeMonitoringSettingTest.php
@@ -59,6 +59,30 @@ test('uptime monitoring can be re-enabled from the project settings', function (
     expect($project->fresh()->uptime_monitoring_enabled)->toBeTrue();
 });
 
+test('omitting the uptime monitoring field preserves the stored value', function () {
+    $user = User::factory()->create();
+    $team = $user->currentTeam;
+
+    foreach ([true, false] as $enabled) {
+        $project = Project::factory()->create([
+            'team_id' => $team->id,
+            'url' => 'https://example.com',
+            'uptime_monitoring_enabled' => $enabled,
+        ]);
+
+        $this->actingAs($user)
+            ->patch(route('projects.update', ['current_team' => $team->slug, 'project' => $project->slug]), [
+                'name' => 'Renamed Project',
+                'url' => $project->url,
+                'uptime_check_interval' => 60,
+                'retention_days' => 7,
+            ])
+            ->assertRedirect();
+
+        expect($project->fresh()->uptime_monitoring_enabled)->toBe($enabled);
+    }
+});
+
 test('the uptime monitoring scope only returns monitorable projects', function () {
     $user = User::factory()->create();
     $team = $user->currentTeam;

--- a/tests/Feature/ProjectUptimeMonitoringSettingTest.php
+++ b/tests/Feature/ProjectUptimeMonitoringSettingTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use App\Models\Project;
+use App\Models\User;
+
+test('uptime monitoring is enabled by default for new projects', function () {
+    $user = User::factory()->create();
+    $project = Project::factory()->create(['team_id' => $user->currentTeam->id]);
+
+    expect($project->fresh()->uptime_monitoring_enabled)->toBeTrue();
+});
+
+test('uptime monitoring can be disabled from the project settings', function () {
+    $user = User::factory()->create();
+    $team = $user->currentTeam;
+    $project = Project::factory()->create([
+        'team_id' => $team->id,
+        'url' => 'https://example.com',
+        'uptime_monitoring_enabled' => true,
+        'last_uptime_status' => 'down',
+        'last_uptime_check_at' => now(),
+    ]);
+
+    $this->actingAs($user)
+        ->patch(route('projects.update', ['current_team' => $team->slug, 'project' => $project->slug]), [
+            'name' => $project->name,
+            'url' => $project->url,
+            'uptime_monitoring_enabled' => false,
+            'uptime_check_interval' => 60,
+            'retention_days' => 7,
+        ])
+        ->assertRedirect();
+
+    $project->refresh();
+    expect($project->uptime_monitoring_enabled)->toBeFalse();
+    expect($project->last_uptime_status)->toBeNull();
+    expect($project->last_uptime_check_at)->toBeNull();
+});
+
+test('uptime monitoring can be re-enabled from the project settings', function () {
+    $user = User::factory()->create();
+    $team = $user->currentTeam;
+    $project = Project::factory()->create([
+        'team_id' => $team->id,
+        'url' => 'https://example.com',
+        'uptime_monitoring_enabled' => false,
+    ]);
+
+    $this->actingAs($user)
+        ->patch(route('projects.update', ['current_team' => $team->slug, 'project' => $project->slug]), [
+            'name' => $project->name,
+            'url' => $project->url,
+            'uptime_monitoring_enabled' => true,
+            'uptime_check_interval' => 60,
+            'retention_days' => 7,
+        ])
+        ->assertRedirect();
+
+    expect($project->fresh()->uptime_monitoring_enabled)->toBeTrue();
+});
+
+test('the uptime monitoring scope only returns monitorable projects', function () {
+    $user = User::factory()->create();
+    $team = $user->currentTeam;
+
+    $monitored = Project::factory()->create([
+        'team_id' => $team->id,
+        'url' => 'https://example.com',
+        'uptime_monitoring_enabled' => true,
+    ]);
+
+    Project::factory()->create([
+        'team_id' => $team->id,
+        'url' => 'https://example.com',
+        'uptime_monitoring_enabled' => false,
+    ]);
+
+    Project::factory()->create([
+        'team_id' => $team->id,
+        'url' => null,
+        'uptime_monitoring_enabled' => true,
+    ]);
+
+    expect(Project::withUptimeMonitoring()->pluck('id')->all())->toBe([$monitored->id]);
+});


### PR DESCRIPTION
For some projects you might not want to enable uptime monitoring. In our case, we have some app running behind an external SSO solution. Uptime monitoring then doesn't make any sense as it's not pinging our app. 