### PR TITLE
fix: isolate phpunit test env from container OS env vars

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,20 +18,35 @@
         </include>
     </source>
     <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="APP_MAINTENANCE_DRIVER" value="file"/>
-        <env name="BCRYPT_ROUNDS" value="4"/>
-        <env name="BROADCAST_CONNECTION" value="null"/>
-        <env name="CACHE_STORE" value="array"/>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
-        <env name="DB_URL" value=""/>
-        <env name="MAIL_MAILER" value="array"/>
-        <env name="QUEUE_CONNECTION" value="sync"/>
-        <env name="SESSION_DRIVER" value="array"/>
-        <env name="PULSE_ENABLED" value="false"/>
-        <env name="TELESCOPE_ENABLED" value="false"/>
-        <env name="NIGHTWATCH_ENABLED" value="false"/>
-        <env name="ALLOW_REGISTRATION" value="true"/>
+        <env name="APP_ENV" value="testing" force="true"/>
+        <server name="APP_ENV" value="testing" force="true"/>
+        <env name="APP_MAINTENANCE_DRIVER" value="file" force="true"/>
+        <server name="APP_MAINTENANCE_DRIVER" value="file" force="true"/>
+        <env name="BCRYPT_ROUNDS" value="4" force="true"/>
+        <server name="BCRYPT_ROUNDS" value="4" force="true"/>
+        <env name="BROADCAST_CONNECTION" value="null" force="true"/>
+        <server name="BROADCAST_CONNECTION" value="null" force="true"/>
+        <env name="CACHE_STORE" value="array" force="true"/>
+        <server name="CACHE_STORE" value="array" force="true"/>
+        <env name="DB_CONNECTION" value="sqlite" force="true"/>
+        <server name="DB_CONNECTION" value="sqlite" force="true"/>
+        <env name="DB_DATABASE" value=":memory:" force="true"/>
+        <server name="DB_DATABASE" value=":memory:" force="true"/>
+        <env name="DB_URL" value="" force="true"/>
+        <server name="DB_URL" value="" force="true"/>
+        <env name="MAIL_MAILER" value="array" force="true"/>
+        <server name="MAIL_MAILER" value="array" force="true"/>
+        <env name="QUEUE_CONNECTION" value="sync" force="true"/>
+        <server name="QUEUE_CONNECTION" value="sync" force="true"/>
+        <env name="SESSION_DRIVER" value="array" force="true"/>
+        <server name="SESSION_DRIVER" value="array" force="true"/>
+        <env name="PULSE_ENABLED" value="false" force="true"/>
+        <server name="PULSE_ENABLED" value="false" force="true"/>
+        <env name="TELESCOPE_ENABLED" value="false" force="true"/>
+        <server name="TELESCOPE_ENABLED" value="false" force="true"/>
+        <env name="NIGHTWATCH_ENABLED" value="false" force="true"/>
+        <server name="NIGHTWATCH_ENABLED" value="false" force="true"/>
+        <env name="ALLOW_REGISTRATION" value="true" force="true"/>
+        <server name="ALLOW_REGISTRATION" value="true" force="true"/>
     </php>
 </phpunit>

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -23,7 +23,12 @@ test('new users can register', function () {
 });
 
 test('registration is disabled when ALLOW_REGISTRATION is false', function () {
+    // Both superglobals must be set: Laravel's env() resolves $_SERVER before
+    // $_ENV (see vlucas/phpdotenv's ServerConstAdapter), so overriding only
+    // $_ENV is silently ignored whenever $_SERVER already holds a value for
+    // this key (e.g. phpunit.xml's <server> entries, or a real OS env var).
     $_ENV['ALLOW_REGISTRATION'] = 'false';
+    $_SERVER['ALLOW_REGISTRATION'] = 'false';
     $this->refreshApplication();
 
     $response = $this->get('/register');
@@ -37,6 +42,6 @@ test('registration is disabled when ALLOW_REGISTRATION is false', function () {
     ]);
     $responseStore->assertStatus(404);
 
-    unset($_ENV['ALLOW_REGISTRATION']);
+    unset($_ENV['ALLOW_REGISTRATION'], $_SERVER['ALLOW_REGISTRATION']);
     $this->refreshApplication();
 });


### PR DESCRIPTION
## Problem

Running tests (`vendor/bin/pest`, `php artisan test`, `vendor/bin/phpunit`) **inside a container started from `docker-compose.yaml`** silently connects to the real database and runs with the real `APP_ENV`, instead of the isolated config declared in `phpunit.xml`.

`docker-compose.yaml`'s `app`/`horizon`/`schedule-worker`/`reverb`/`caddy` services use `env_file: - .env`, which injects every key in `.env` as a **real OS-level environment variable**, not just a file for Laravel's Dotenv loader to parse later. PHPUnit's `<env>` tags only apply when the variable isn't already set (`force` defaults to `false`), so every `<env>` in `phpunit.xml` was silently a no-op for any key that also exists in `.env` — which `APP_ENV`/`DB_CONNECTION`/etc. always do (confirmed in both `.env.example` and `.env.prod`).

## Fix

Adding `force="true"` to `<env>` is not sufficient by itself — verified empirically. PHPUnit's `PhpHandler::handleEnvVariables()` only ever writes `$_ENV`/`putenv()`, never `$_SERVER`. Laravel's `env()` resolves through phpdotenv's `RepositoryBuilder`, whose reader order is `$_SERVER` → `$_ENV` → `getenv()` (first reader with the key wins), and `$_SERVER` is already populated from the real OS env before PHPUnit's bootstrap runs — so a forced `<env>` still loses.

This PR mirrors every `<env>` entry in `phpunit.xml` with a matching `<server ... force="true"/>` entry, which does correctly override `$_SERVER` too.

Also fixes `tests/Feature/Auth/RegistrationTest.php`'s "registration is disabled" test, which only overrode `$_ENV['ALLOW_REGISTRATION']` at runtime — that override is now shadowed by the force-set `$_SERVER`, so the test needs to set both superglobals to keep working.

## Verification

Verified inside a running `docker-compose` container (`laraowl-app-1`):
- Before: `env('APP_ENV')` → `production`, `DB::connection()->getDriverName()` → `pgsql` (even with `force="true"` on `<env>` alone).
- After: `env('APP_ENV')` → `testing`, driver → `sqlite`.
- Full suite: 239 passed, 0 failed, 3 skipped (previously 1 failure, in the test this PR also touches).

## Why draft / asking for input

I'm not fully confident mirroring every entry into `<server>` is the right shape for this fix, versus alternatives — e.g. not injecting `.env` as real OS env vars in `docker-compose.yaml` in the first place (dropping `env_file` in favor of a mounted `.env` file that only Laravel's Dotenv parses), or scoping the `<server>` overrides to just the DB/session-critical keys instead of all of them. Opening as draft to get other contributors' take before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)