### PR TITLE
Fix for 502 errors: Import the namespaced defer() helper in UpdateService

### DIFF
--- a/app/Services/UpdateService.php
+++ b/app/Services/UpdateService.php
@@ -7,6 +7,7 @@ use App\Support\Version;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use function Illuminate\Support\defer;
 
 class UpdateService
 {

--- a/tests/Unit/DeferHelperImportTest.php
+++ b/tests/Unit/DeferHelperImportTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Guard against the global defer() being claimed by an extension
+|--------------------------------------------------------------------------
+|
+| Laravel registers its global defer() helper conditionally:
+| Illuminate/Foundation/helpers.php wraps the declaration in
+| if (! function_exists('defer')). A PHP extension that claims the name at
+| startup therefore wins, and an unqualified defer() call inside a namespaced
+| class reaches the extension instead of Laravel.
+|
+| The swoole extension does exactly that, and ships enabled by default on
+| Laravel Forge servers (it is part of the standard php{version}-* install
+| set, whether or not Octane is used). Its defer() throws
+| Swoole\Error: API must be called in the coroutine when there is no
+| coroutine, which is fatal, kills the PHP-FPM worker, and reaches the
+| visitor as a 502.
+|
+| This guard is deliberately static. A behavioural test cannot catch the
+| problem, because without the extension loaded the unqualified call resolves
+| to Laravel's helper and passes. Importing the namespaced function is what
+| the framework itself does everywhere it calls defer() -- see
+| Illuminate\Cache\Repository, the Concurrency drivers and Http\Client\Batch.
+|
+*/
+
+test('every unqualified defer() call imports the namespaced helper', function () {
+    $appPath = dirname(__DIR__, 2).'/app';
+
+    $files = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($appPath, FilesystemIterator::SKIP_DOTS)
+    );
+
+    $offenders = [];
+
+    foreach ($files as $file) {
+        if ($file->getExtension() !== 'php') {
+            continue;
+        }
+
+        $contents = file_get_contents($file->getPathname());
+
+        // A bare defer(...) call: not $x->defer(), not Foo::defer(),
+        // not \defer(), and not a function declaration.
+        $callsDefer = (bool) preg_match('/(?<![\w$>\\\\:])(?<!function )defer\s*\(/', $contents);
+
+        if (! $callsDefer) {
+            continue;
+        }
+
+        if (! str_contains($contents, 'use function Illuminate\Support\defer;')) {
+            $offenders[] = str_replace($appPath.'/', 'app/', $file->getPathname());
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});


### PR DESCRIPTION
Laravel registers its global defer() helper only while the name is still free: Illuminate/Foundation/helpers.php wraps the declaration in if (! function_exists('defer')). An extension that claims the name at startup therefore wins, and the unqualified call in UpdateService reaches the extension instead of Laravel.

The swoole extension does exactly that, and is part of the standard php{version}-* package set installed on Laravel Forge servers, whether or not Octane is used. Its defer() throws
Swoole\Error: API must be called in the coroutine outside a coroutine. Uncaught, that is fatal, kills the PHP-FPM worker, and reaches the visitor as a 502.

deferRefresh() is reached from HandleInertiaRequests::share() via pendingUpdate(), which runs for the instance operator on every Inertia render. The crash therefore hit the first page rendered after the update cache went stale, most visibly the dashboard right after logging in, and looked like a random intermittent 502.

Importing the function is what the framework itself does everywhere it calls defer() -- see Illuminate\Cache\Repository, the Concurrency drivers and Illuminate\Http\Client\Batch.

The accompanying guard is static on purpose. A behavioural test cannot catch this, because without the extension loaded the unqualified call resolves to Laravel's helper and passes either way.