### PR TITLE
Make alert rule occurrence threshold and time window actually work

### DIFF
--- a/app/Services/AlertService.php
+++ b/app/Services/AlertService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\AlertRule;
 use App\Models\Issue;
 use App\Models\Project;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 
 class AlertService
@@ -17,16 +18,15 @@ class AlertService
     }
 
     /**
-     * Notify about a new issue (exception).
+     * Notify about an exception issue occurrence.
+     *
+     * Called on every occurrence; each rule decides whether its occurrence
+     * threshold and time window are satisfied before an alert is dispatched.
      */
     public function notifyNewIssue(Issue $issue)
     {
         $project = $issue->project;
-        $rules = $project->alertRules()
-            ->where('event_type', 'new_exception')
-            ->where('is_enabled', true)
-            ->with('integrations')
-            ->get();
+        $rules = $this->rulesMatchingIssue($project, 'new_exception', $issue);
 
         $title = '🚨 New Exception: '.$issue->title;
         $message = $issue->message;
@@ -43,16 +43,15 @@ class AlertService
     }
 
     /**
-     * Notify about slow performance violation.
+     * Notify about a slow performance issue occurrence.
+     *
+     * Called on every occurrence; each rule decides whether its occurrence
+     * threshold and time window are satisfied before an alert is dispatched.
      */
     public function notifySlowPerformance(Issue $issue)
     {
         $project = $issue->project;
-        $rules = $project->alertRules()
-            ->where('event_type', 'high_latency')
-            ->where('is_enabled', true)
-            ->with('integrations')
-            ->get();
+        $rules = $this->rulesMatchingIssue($project, 'high_latency', $issue);
 
         $title = '⏱️ High Latency: '.$issue->title;
         $message = $issue->message;
@@ -140,6 +139,82 @@ class AlertService
         foreach ($rules as $rule) {
             $this->dispatchAlert($rule, $title, $message, $fields, $url);
         }
+    }
+
+    /**
+     * The enabled rules of the given event type whose occurrence threshold and
+     * time window are satisfied by the current state of the issue.
+     *
+     * @return Collection<int, AlertRule>
+     */
+    protected function rulesMatchingIssue(Project $project, string $eventType, Issue $issue)
+    {
+        $rules = $project->alertRules()
+            ->where('event_type', $eventType)
+            ->where('is_enabled', true)
+            ->with('integrations')
+            ->get();
+
+        if ($rules->isEmpty()) {
+            return $rules;
+        }
+
+        $occurrencesInWindow = [];
+
+        return $rules->filter(function (AlertRule $rule) use ($issue, &$occurrencesInWindow) {
+            return $this->issueSatisfiesRule($rule, $issue, $occurrencesInWindow);
+        });
+    }
+
+    /**
+     * Decide whether an issue occurrence should trigger the rule.
+     *
+     * Settings:
+     *  - `occurrence_threshold` (default 1): alert only after this many occurrences.
+     *  - `time_window` (minutes, default 0): count occurrences within this window.
+     *    With no window the issue's lifetime occurrences_count is used.
+     *
+     * A rule fires once when the threshold is crossed. With a window it may fire
+     * again once the window has elapsed; without a window it fires only once
+     * per issue.
+     *
+     * @param  array<int, int>  $occurrencesInWindow  Per-window occurrence counts, shared across rules to avoid repeated queries.
+     */
+    protected function issueSatisfiesRule(AlertRule $rule, Issue $issue, array &$occurrencesInWindow): bool
+    {
+        $settings = $rule->settings ?? [];
+        $threshold = max(1, (int) ($settings['occurrence_threshold'] ?? 1));
+        $windowMinutes = max(0, (int) ($settings['time_window'] ?? 0));
+
+        if ($threshold === 1) {
+            return $issue->wasRecentlyCreated;
+        }
+
+        if ($windowMinutes === 0) {
+            $occurrences = (int) $issue->occurrences_count;
+        } else {
+            $occurrences = $occurrencesInWindow[$windowMinutes] ??= $issue->records()
+                ->where('created_at', '>=', now()->subMinutes($windowMinutes))
+                ->count();
+        }
+
+        if ($occurrences < $threshold) {
+            return false;
+        }
+
+        $thresholdKey = "alert_rule_{$rule->id}_issue_{$issue->id}_threshold_reached";
+
+        if (Cache::has($thresholdKey)) {
+            return false;
+        }
+
+        if ($windowMinutes === 0) {
+            Cache::forever($thresholdKey, true);
+        } else {
+            Cache::put($thresholdKey, true, now()->addMinutes($windowMinutes));
+        }
+
+        return true;
     }
 
     /**

--- a/app/Services/IngestService.php
+++ b/app/Services/IngestService.php
@@ -190,11 +190,9 @@ class IngestService
             'message' => $message, // Update with latest duration
         ]);
 
-        if ($issue->wasRecentlyCreated) {
-            $this->alertService->notifySlowPerformance($issue);
-        }
-
         $record->update(['issue_id' => $issue->id]);
+
+        $this->alertService->notifySlowPerformance($issue);
     }
 
     /**
@@ -219,11 +217,9 @@ class IngestService
         $issue->increment('occurrences_count');
         $issue->update(['last_seen_at' => now()]);
 
-        if ($issue->wasRecentlyCreated) {
-            $this->alertService->notifyNewIssue($issue);
-        }
-
         $record->update(['issue_id' => $issue->id]);
+
+        $this->alertService->notifyNewIssue($issue);
 
         // Detect Spike
         $this->detectErrorSpike($project);

--- a/database/migrations/2026_08_26_173455_add_issue_created_at_index_to_records_table.php
+++ b/database/migrations/2026_08_26_173455_add_issue_created_at_index_to_records_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Supports counting an issue's occurrences within an alert rule's time
+     * window without scanning the (potentially huge) records table.
+     */
+    public function up(): void
+    {
+        Schema::table('records', function (Blueprint $table) {
+            $table->index(['issue_id', 'created_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('records', function (Blueprint $table) {
+            $table->dropIndex(['issue_id', 'created_at']);
+        });
+    }
+};

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -6,11 +6,6 @@ import AppLayout from '@/layouts/app-layout';
 import AuthLayout from '@/layouts/auth-layout';
 import SettingsLayout from '@/layouts/settings/layout';
 import '@/lib/echo';
-import { configureEcho } from '@laravel/echo-react';
-
-configureEcho({
-    broadcaster: 'reverb',
-});
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -6,6 +6,11 @@ import AppLayout from '@/layouts/app-layout';
 import AuthLayout from '@/layouts/auth-layout';
 import SettingsLayout from '@/layouts/settings/layout';
 import '@/lib/echo';
+import { configureEcho } from '@laravel/echo-react';
+
+configureEcho({
+    broadcaster: 'reverb',
+});
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 

--- a/tests/Feature/AlertRuleThresholdTest.php
+++ b/tests/Feature/AlertRuleThresholdTest.php
@@ -1,0 +1,212 @@
+<?php
+
+use App\Models\AlertRule;
+use App\Models\Integration;
+use App\Models\Issue;
+use App\Models\Project;
+use App\Models\Record;
+use App\Models\Team;
+use App\Services\AlertService;
+use App\Services\IntegrationService;
+use Illuminate\Support\Facades\Cache;
+
+beforeEach(function () {
+    Cache::flush();
+
+    $this->team = Team::factory()->create();
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+
+    $this->integration = Integration::create([
+        'project_id' => $this->project->id,
+        'name' => 'Slack',
+        'type' => 'slack',
+        'data' => ['webhook_url' => 'https://hooks.slack.test/abc'],
+        'is_enabled' => true,
+    ]);
+
+    $this->integrationService = Mockery::mock(IntegrationService::class);
+    $this->alertService = new AlertService($this->integrationService);
+});
+
+function createRule(Project $project, Integration $integration, array $settings, string $eventType = 'new_exception'): AlertRule
+{
+    $rule = $project->alertRules()->create([
+        'name' => 'Rule',
+        'event_type' => $eventType,
+        'settings' => $settings,
+        'is_enabled' => true,
+    ]);
+    $rule->integrations()->attach($integration);
+
+    return $rule;
+}
+
+function createIssue(Project $project, int $occurrences = 1, bool $recentlyCreated = false): Issue
+{
+    $issue = $project->issues()->create([
+        'hash' => md5('issue-'.$occurrences),
+        'title' => 'RuntimeException',
+        'message' => 'Something broke',
+        'status' => 'open',
+        'occurrences_count' => $occurrences,
+        'first_seen_at' => now(),
+        'last_seen_at' => now(),
+    ]);
+    $issue->wasRecentlyCreated = $recentlyCreated;
+
+    return $issue;
+}
+
+test('a rule with threshold 1 fires only when the issue is new', function () {
+    createRule($this->project, $this->integration, ['occurrence_threshold' => 1, 'throttle_period' => 0]);
+
+    $this->integrationService->shouldReceive('send')->once();
+    $this->alertService->notifyNewIssue(createIssue($this->project, 1, true));
+
+    $this->integrationService->shouldNotReceive('send');
+    $this->alertService->notifyNewIssue(createIssue($this->project, 2, false));
+});
+
+test('a rule without threshold settings behaves like threshold 1', function () {
+    createRule($this->project, $this->integration, ['frequency' => 'immediate', 'throttle_period' => 0]);
+
+    $this->integrationService->shouldReceive('send')->once();
+    $this->alertService->notifyNewIssue(createIssue($this->project, 1, true));
+});
+
+test('a rule with a threshold and no window fires once when lifetime occurrences reach it', function () {
+    createRule($this->project, $this->integration, ['occurrence_threshold' => 3, 'time_window' => 0, 'throttle_period' => 0]);
+
+    $issue = createIssue($this->project, 1, true);
+
+    $this->integrationService->shouldNotReceive('send');
+    $this->alertService->notifyNewIssue($issue);
+
+    $issue->occurrences_count = 2;
+    $issue->wasRecentlyCreated = false;
+    $this->alertService->notifyNewIssue($issue);
+
+    Mockery::close();
+    $this->integrationService = Mockery::mock(IntegrationService::class);
+    $this->alertService = new AlertService($this->integrationService);
+
+    $this->integrationService->shouldReceive('send')->once();
+    $issue->occurrences_count = 3;
+    $this->alertService->notifyNewIssue($issue);
+
+    $issue->occurrences_count = 4;
+    $this->alertService->notifyNewIssue($issue);
+});
+
+test('a rule with a time window only counts occurrences inside the window', function () {
+    createRule($this->project, $this->integration, ['occurrence_threshold' => 3, 'time_window' => 10, 'throttle_period' => 0]);
+
+    $issue = createIssue($this->project, 5);
+
+    // Three old occurrences outside the window, two inside.
+    Record::factory()->count(3)->create([
+        'project_id' => $this->project->id,
+        'issue_id' => $issue->id,
+        'type' => 'exception',
+        'created_at' => now()->subMinutes(30),
+    ]);
+    Record::factory()->count(2)->create([
+        'project_id' => $this->project->id,
+        'issue_id' => $issue->id,
+        'type' => 'exception',
+        'created_at' => now()->subMinutes(2),
+    ]);
+
+    $this->integrationService->shouldNotReceive('send');
+    $this->alertService->notifyNewIssue($issue);
+
+    Mockery::close();
+    $this->integrationService = Mockery::mock(IntegrationService::class);
+    $this->alertService = new AlertService($this->integrationService);
+
+    Record::factory()->create([
+        'project_id' => $this->project->id,
+        'issue_id' => $issue->id,
+        'type' => 'exception',
+        'created_at' => now(),
+    ]);
+
+    $this->integrationService->shouldReceive('send')->once();
+    $this->alertService->notifyNewIssue($issue);
+
+    // Further occurrences inside the same window do not re-alert.
+    Record::factory()->create([
+        'project_id' => $this->project->id,
+        'issue_id' => $issue->id,
+        'type' => 'exception',
+        'created_at' => now(),
+    ]);
+    $this->alertService->notifyNewIssue($issue);
+});
+
+test('a windowed rule can fire again once the window has elapsed', function () {
+    createRule($this->project, $this->integration, ['occurrence_threshold' => 2, 'time_window' => 10, 'throttle_period' => 0]);
+
+    $issue = createIssue($this->project, 4);
+
+    Record::factory()->count(2)->create([
+        'project_id' => $this->project->id,
+        'issue_id' => $issue->id,
+        'type' => 'exception',
+        'created_at' => now(),
+    ]);
+
+    $this->integrationService->shouldReceive('send')->once();
+    $this->alertService->notifyNewIssue($issue);
+
+    $this->travel(11)->minutes();
+
+    Record::factory()->count(2)->create([
+        'project_id' => $this->project->id,
+        'issue_id' => $issue->id,
+        'type' => 'exception',
+        'created_at' => now(),
+    ]);
+
+    $this->integrationService->shouldReceive('send')->once();
+    $this->alertService->notifyNewIssue($issue);
+});
+
+test('rules are evaluated independently for the same issue', function () {
+    createRule($this->project, $this->integration, ['occurrence_threshold' => 1, 'throttle_period' => 0]);
+    createRule($this->project, $this->integration, ['occurrence_threshold' => 5, 'throttle_period' => 0]);
+
+    // New issue: only the threshold-1 rule fires.
+    $this->integrationService->shouldReceive('send')->once();
+    $this->alertService->notifyNewIssue(createIssue($this->project, 1, true));
+});
+
+test('high latency rules honour the occurrence threshold too', function () {
+    createRule($this->project, $this->integration, ['occurrence_threshold' => 2, 'throttle_period' => 0], 'high_latency');
+
+    $issue = createIssue($this->project, 1, true);
+
+    $this->integrationService->shouldNotReceive('send');
+    $this->alertService->notifySlowPerformance($issue);
+
+    Mockery::close();
+    $this->integrationService = Mockery::mock(IntegrationService::class);
+    $this->alertService = new AlertService($this->integrationService);
+
+    $this->integrationService->shouldReceive('send')->once();
+    $issue->occurrences_count = 2;
+    $issue->wasRecentlyCreated = false;
+    $this->alertService->notifySlowPerformance($issue);
+});
+
+test('disabled rules and disabled integrations are skipped', function () {
+    $rule = createRule($this->project, $this->integration, ['occurrence_threshold' => 1, 'throttle_period' => 0]);
+    $rule->update(['is_enabled' => false]);
+
+    $this->integrationService->shouldNotReceive('send');
+    $this->alertService->notifyNewIssue(createIssue($this->project, 1, true));
+
+    $rule->update(['is_enabled' => true]);
+    $this->integration->update(['is_enabled' => false]);
+    $this->alertService->notifyNewIssue(createIssue($this->project, 2, true));
+});

--- a/tests/Feature/IngestAlertThresholdTest.php
+++ b/tests/Feature/IngestAlertThresholdTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\Issue;
+use App\Models\Project;
+use App\Models\Team;
+use App\Services\AlertService;
+use App\Services\IngestService;
+use App\Services\RollupWriter;
+use App\Services\SecurityService;
+
+test('ingest notifies the alert service on every exception occurrence', function () {
+    $team = Team::factory()->create();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+
+    $alertService = Mockery::mock(AlertService::class);
+    $alertService->shouldReceive('notifyNewIssue')
+        ->twice()
+        ->with(Mockery::on(function (Issue $issue) {
+            // The current record is linked before the alert service evaluates it.
+            return $issue->records()->count() === (int) $issue->occurrences_count;
+        }));
+    $alertService->shouldReceive('notifyErrorSpike')->never();
+
+    $ingestService = new IngestService($alertService, app(SecurityService::class), app(RollupWriter::class));
+
+    $exception = ['t' => 'exception', 'class' => 'RuntimeException', 'message' => 'Boom', 'file' => 'a.php', 'line' => 1];
+
+    $ingestService->ingest($project, [$exception]);
+    $ingestService->ingest($project, [$exception]);
+
+    expect(Issue::where('project_id', $project->id)->first()->occurrences_count)->toBe(2);
+});


### PR DESCRIPTION
## Summary

The alert rule form exposes **Occurrence Threshold** and **Time Window (Mins)**, and stores them in `alert_rules.settings`, but nothing ever read them. `new_exception` and `high_latency` rules fired on the very first occurrence no matter what was configured.

This PR makes those settings gate alerts.

## Changes

**`app/Services/AlertService.php`**
- `notifyNewIssue()` / `notifySlowPerformance()` now filter rules through `issueSatisfiesRule()`:
  - `occurrence_threshold` ≤ 1 or unset → alert when the issue is new. Identical to the previous behaviour, so existing and default rules are unaffected.
  - threshold > 1, no `time_window` → uses the issue's lifetime `occurrences_count`; fires once when reached.
  - threshold > 1 with `time_window` (minutes) → counts the issue's `records` inside the window; fires once per window and can fire again after the window elapses.
- The window count is computed once per distinct window and shared across rules, so multiple rules on the same project don't each query.
- Throttling (`throttle_period`) is unchanged and still applies on top.

**`app/Services/IngestService.php`**
- The alert service is called on every exception / slow-request occurrence (not only the first) and only after the record is linked to the issue, so the window count includes the current hit. All decision-making lives in `AlertService`.

**Migration** `add_issue_created_at_index_to_records_table`
- Composite index on `records (issue_id, created_at)`. The FK alone does not create an index on Postgres, and the window count would otherwise scan `records`.

## Tests

- `tests/Feature/AlertRuleThresholdTest.php`: threshold 1 / missing settings, lifetime threshold fires exactly once, window ignores old occurrences, re-fires after the window elapses, multiple rules evaluated independently, `high_latency` rules, disabled rules and integrations skipped.
- `tests/Feature/IngestAlertThresholdTest.php`: ingest notifies on every occurrence with the record already linked.

Full suite: 279 passed.

## Not in scope

- `success_rate_drop` is still selectable in the UI but has no evaluator.
- `error_spike` rules still use the project-level `spike_threshold` / `spike_window` rather than the per-rule fields.