### PR TITLE
Prevent health check runs from piling up and exhausting memory

### DIFF
--- a/app/Console/Commands/CheckProjectUptime.php
+++ b/app/Console/Commands/CheckProjectUptime.php
@@ -7,6 +7,8 @@ use App\Models\Project;
 use App\Services\AlertService;
 use App\Services\IntegrationService;
 use Illuminate\Console\Command;
+use Illuminate\Http\Client\Pool;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 
 class CheckProjectUptime extends Command
@@ -28,27 +30,30 @@ class CheckProjectUptime extends Command
     /**
      * Execute the console command.
      */
-    public function handle(AlertService $alertService)
-    {
-        // 1. Check Uptime
-        $this->performUptimeChecks($alertService);
+    /**
+     * Maximum number of uptime requests in flight at the same time.
+     */
+    protected const CONCURRENCY = 25;
 
-        // 2. Check Heartbeats
+    /**
+     * Execute the console command.
+     *
+     * The scheduler runs this command every 30 seconds, so a single run only
+     * performs one round of checks and must finish well within that window.
+     */
+    public function handle(AlertService $alertService): int
+    {
+        $this->performUptimeChecks($alertService);
         $this->checkHeartbeats($alertService);
 
-        // 3. Support sub-minute intervals (30s)
-        if (Project::withUptimeMonitoring()->where('uptime_check_interval', '<', 60)->exists()) {
-            $this->info('Waiting 30 seconds for next sub-minute check...');
-            sleep(30);
-            $this->performUptimeChecks($alertService);
-        }
-
         $this->info('Health checks completed.');
+
+        return self::SUCCESS;
     }
 
-    protected function performUptimeChecks(AlertService $alertService)
+    protected function performUptimeChecks(AlertService $alertService): void
     {
-        $projects = Project::withUptimeMonitoring()->get()->filter(function ($project) {
+        $projects = Project::withUptimeMonitoring()->get()->filter(function (Project $project) {
             if (is_null($project->last_uptime_check_at)) {
                 return true;
             }
@@ -56,30 +61,36 @@ class CheckProjectUptime extends Command
             return $project->last_uptime_check_at->addSeconds($project->uptime_check_interval)->isPast();
         });
 
-        foreach ($projects as $project) {
-            $this->checkUptime($project, $alertService);
+        foreach ($projects->chunk(self::CONCURRENCY) as $batch) {
+            $batch = $batch->values();
+            $start = microtime(true);
+
+            $responses = Http::pool(fn (Pool $pool) => $batch->map(
+                fn (Project $project) => $pool->retry(2, 1000, throw: false)->timeout(10)->get($project->url)
+            )->all());
+
+            foreach ($batch as $index => $project) {
+                $this->recordUptimeResult($project, $responses[$index], $start, $alertService);
+            }
         }
     }
 
-    protected function checkUptime(Project $project, AlertService $alertService)
+    protected function recordUptimeResult(Project $project, Response|\Throwable $response, float $start, AlertService $alertService): void
     {
-        $start = microtime(true);
         $status = 'up';
         $statusCode = 0;
         $error = null;
 
-        try {
-            $response = Http::retry(2, 1000, throw: false)->timeout(10)->get($project->url);
+        if ($response instanceof \Throwable) {
+            $status = 'down';
+            $error = $response->getMessage();
+        } else {
             $statusCode = $response->status();
 
             if ($response->failed()) {
                 $status = 'down';
                 $error = "HTTP error status: {$statusCode}";
             }
-        } catch (\Exception $e) {
-            $status = 'down';
-            $error = $e->getMessage();
-            $statusCode = 0;
         }
 
         $responseTime = round((microtime(true) - $start) * 1000); // in ms
@@ -114,7 +125,7 @@ class CheckProjectUptime extends Command
         }
     }
 
-    protected function checkHeartbeats(AlertService $alertService)
+    protected function checkHeartbeats(AlertService $alertService): void
     {
         $failingHeartbeats = Heartbeat::where('status', 'active')
             ->get()
@@ -127,7 +138,7 @@ class CheckProjectUptime extends Command
         }
     }
 
-    protected function notifyRecovery(Project $project, AlertService $alertService)
+    protected function notifyRecovery(Project $project, AlertService $alertService): void
     {
         $rules = $project->alertRules()
             ->where('event_type', 'uptime_down')

--- a/app/Services/IntegrationService.php
+++ b/app/Services/IntegrationService.php
@@ -113,7 +113,7 @@ class IntegrationService
             ];
         }
 
-        Http::post($webhookUrl, ['blocks' => $blocks]);
+        Http::timeout(10)->post($webhookUrl, ['blocks' => $blocks]);
     }
 
     protected function sendToDiscord(Integration $integration, string $title, string $message, array $fields = [], ?string $url = null): void
@@ -128,7 +128,7 @@ class IntegrationService
             $discordFields[] = ['name' => $label, 'value' => (string) $value, 'inline' => true];
         }
 
-        Http::post($webhookUrl, [
+        Http::timeout(10)->post($webhookUrl, [
             'embeds' => [[
                 'title' => $title,
                 'description' => $message,
@@ -157,7 +157,7 @@ class IntegrationService
             $text .= "[View Details]({$url})";
         }
 
-        Http::post("https://api.telegram.org/bot{$botToken}/sendMessage", [
+        Http::timeout(10)->post("https://api.telegram.org/bot{$botToken}/sendMessage", [
             'chat_id' => $chatId,
             'text' => $text,
             'parse_mode' => 'Markdown',
@@ -171,7 +171,7 @@ class IntegrationService
             return;
         }
 
-        Http::post($webhookUrl, [
+        Http::timeout(10)->post($webhookUrl, [
             'event' => 'laraowl.alert',
             'title' => $title,
             'message' => $message,

--- a/routes/console.php
+++ b/routes/console.php
@@ -9,6 +9,9 @@ Artisan::command('inspire', function () {
 
 use Illuminate\Support\Facades\Schedule;
 
-Schedule::command('projects:check-health')->everyThirtySeconds();
+Schedule::command('projects:check-health')
+    ->everyThirtySeconds()
+    ->withoutOverlapping(5)
+    ->runInBackground();
 Schedule::command('model:prune')->daily();
 Schedule::command('laraowl:update --check')->daily();

--- a/tests/Feature/CheckProjectUptimeTest.php
+++ b/tests/Feature/CheckProjectUptimeTest.php
@@ -6,6 +6,7 @@ use App\Services\AlertService;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Request;
+use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 
@@ -164,4 +165,76 @@ test('it logs down and sends alert when all attempts fail', function () {
     expect($project->last_uptime_status)->toBe('down');
     expect($project->uptimeChecks)->toHaveCount(1);
     expect($project->uptimeChecks->first()->status)->toBe('down');
+});
+
+test('it checks multiple projects concurrently in a single run', function () {
+    $team = Team::factory()->create();
+    $projects = Project::factory()->count(3)->sequence(
+        ['url' => 'https://one.example.com'],
+        ['url' => 'https://two.example.com'],
+        ['url' => 'https://three.example.com'],
+    )->create([
+        'team_id' => $team->id,
+        'last_uptime_status' => null,
+    ]);
+
+    Http::fake([
+        'one.example.com' => Http::response('OK', 200),
+        'two.example.com' => Http::response('Error', 500),
+        'three.example.com' => Http::response('OK', 200),
+    ]);
+
+    $alertService = Mockery::mock(AlertService::class);
+    $alertService->shouldReceive('notifyUptimeDown')->once();
+    $this->instance(AlertService::class, $alertService);
+
+    $this->artisan('projects:check-health')
+        ->assertExitCode(0);
+
+    Http::assertSent(fn ($request) => $request->url() === 'https://one.example.com');
+    Http::assertSent(fn ($request) => $request->url() === 'https://three.example.com');
+    // The failing project is retried once before being marked down.
+    Http::assertSentCount(4);
+
+    expect($projects[0]->refresh()->last_uptime_status)->toBe('up');
+    expect($projects[1]->refresh()->last_uptime_status)->toBe('down');
+    expect($projects[1]->uptimeChecks->first()->status_code)->toBe(500);
+    expect($projects[2]->refresh()->last_uptime_status)->toBe('up');
+});
+
+test('it performs a single round of checks for sub-minute intervals without sleeping', function () {
+    $team = Team::factory()->create();
+    Project::factory()->create([
+        'team_id' => $team->id,
+        'url' => 'https://example.com',
+        'uptime_check_interval' => 30,
+        'last_uptime_status' => null,
+    ]);
+
+    Http::fake([
+        '*' => Http::response('OK', 200),
+    ]);
+
+    $alertService = Mockery::mock(AlertService::class);
+    $alertService->shouldNotReceive('notifyUptimeDown');
+    $this->instance(AlertService::class, $alertService);
+
+    $start = microtime(true);
+
+    $this->artisan('projects:check-health')
+        ->assertExitCode(0);
+
+    expect(microtime(true) - $start)->toBeLessThan(5);
+    Http::assertSentCount(1);
+});
+
+test('the health check schedule prevents overlapping runs', function () {
+    $event = collect(app(Schedule::class)->events())
+        ->first(fn ($event) => str_contains($event->command, 'projects:check-health'));
+
+    expect($event)->not->toBeNull();
+    expect($event->withoutOverlapping)->toBeTrue();
+    expect($event->expiresAt)->toBe(5);
+    expect($event->runInBackground)->toBeTrue();
+    expect($event->repeatSeconds)->toBe(30);
 });

--- a/tests/Feature/IntegrationServiceTimeoutTest.php
+++ b/tests/Feature/IntegrationServiceTimeoutTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\Integration;
+use App\Models\Project;
+use App\Models\Team;
+use App\Services\IntegrationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+uses(RefreshDatabase::class);
+
+test('outgoing integration requests are sent with a timeout', function (string $type, array $data) {
+    $team = Team::factory()->create();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $integration = Integration::create([
+        'project_id' => $project->id,
+        'type' => $type,
+        'name' => ucfirst($type),
+        'data' => $data,
+        'is_enabled' => true,
+    ]);
+
+    $timeouts = [];
+
+    Http::fake(function (Request $request, array $options) use (&$timeouts) {
+        $timeouts[] = $options['timeout'] ?? null;
+
+        return Http::response('ok', 200);
+    });
+
+    app(IntegrationService::class)->send($integration, 'Title', 'Message', ['Key' => 'Value'], 'https://laraowl.test');
+
+    expect($timeouts)->toBe([10]);
+})->with([
+    'slack' => ['slack', ['webhook_url' => 'https://hooks.slack.test/abc']],
+    'discord' => ['discord', ['webhook_url' => 'https://discord.test/api/webhooks/abc']],
+    'telegram' => ['telegram', ['bot_token' => '123:abc', 'chat_id' => '42']],
+    'webhook' => ['webhook', ['url' => 'https://example.test/hook']],
+]);


### PR DESCRIPTION
The projects:check-health command ran every 30 seconds without overlap protection, checked every project sequentially (up to ~32s each when a site is down), then slept another 30 seconds and ran a second round. On a server with a few unreachable projects a single run took minutes, so the scheduler kept stacking new instances (each ~50MB plus a Postgres backend) until the kernel OOM-killed Postgres.

- Schedule with withoutOverlapping(5) and runInBackground()
- Perform one round per run; drop the internal sleep(30) since the scheduler already fires every 30 seconds
- Check projects concurrently via Http::pool (25 at a time) so a run finishes in roughly one request timeout regardless of project count
- Add a 10s timeout to all outgoing integration webhook calls